### PR TITLE
Add organization namespace and command for creating an organization

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -126,6 +126,7 @@ You can fetch the shared item as the second user with `meeco shares:list -a .use
 - [`meeco items:get-thumbnail THUMBNAILID`](#meeco-itemsget-thumbnail-thumbnailid)
 - [`meeco items:list`](#meeco-itemslist)
 - [`meeco items:remove-slot SLOTID`](#meeco-itemsremove-slot-slotid)
+- [`meeco organizations:create`](#meeco-organizationscreate)
 - [`meeco shares:create [FILE]`](#meeco-sharescreate-file)
 - [`meeco shares:create-config`](#meeco-sharescreate-config)
 - [`meeco shares:get ITEMID`](#meeco-sharesget-itemid)
@@ -374,6 +375,28 @@ EXAMPLES
 ```
 
 _See code: [src/commands/items/remove-slot.ts](https://github.com/Meeco/cli/blob/master/src/commands/items/remove-slot.ts)_
+
+## `meeco organizations:create`
+
+Request the creation of a new organization. The organization will remain in the 'requested' state until validated or rejected by meeco
+
+```
+USAGE
+  $ meeco organizations:create
+
+OPTIONS
+  -a, --auth=auth                              (required) [default: .user.yaml] Authorization config file yaml file (if
+                                               not using the default .user.yaml)
+
+  -c, --organizationConfig=organizationConfig  (required) organization config file
+
+  -e, --environment=environment                [default: .environment.yaml] environment config file
+
+EXAMPLE
+  meeco organizations:create -c path/to/organization-config.yaml -a path/to/auth.yaml
+```
+
+_See code: [src/commands/organizations/create.ts](https://github.com/Meeco/cli/blob/master/src/commands/organizations/create.ts)_
 
 ## `meeco shares:create [FILE]`
 
@@ -631,6 +654,18 @@ spec:
     - label: 'My Custom Field'
       name: my_custom # Optional as the API will auto-generated based on 'label'
       value: 'Some Value'
+```
+
+## Organization
+
+```yaml
+kind: Organization
+metadata:
+spec:
+  name: SuperData Inc.
+  description: My super data handling organization
+  url: https://superdata.example.com
+  email: admin@superdata.example.com
 ```
 
 ## Share

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -82,6 +82,9 @@
       "items": {
         "description": "Commands related to a Meeco vault items"
       },
+      "organizations": {
+        "description": "Commands related to managing Organizations within Meeco"
+      },
       "shares": {
         "description": "Commands related to shared data between connected Meeco users"
       },

--- a/packages/cli/src/commands/organizations/create.ts
+++ b/packages/cli/src/commands/organizations/create.ts
@@ -1,0 +1,55 @@
+import { vaultAPIFactory } from '@meeco/sdk';
+import { flags as _flags } from '@oclif/command';
+import { AuthConfig } from '../../configs/auth-config';
+import { OrganizationConfig } from '../../configs/organization-config';
+import { authFlags } from '../../flags/auth-flags';
+import MeecoCommand from '../../util/meeco-command';
+
+export default class CreateOrganisation extends MeecoCommand {
+  static description = `Request the creation of a new organization. \
+The organization will remain in the 'requested' state until validated \
+or rejected by meeco`;
+
+  static examples = [
+    `meeco organizations:create -c path/to/organization-config.yaml -a path/to/auth.yaml`
+  ];
+
+  static flags = {
+    ...MeecoCommand.flags,
+    ...authFlags,
+    organizationConfig: _flags.string({
+      char: 'c',
+      required: true,
+      description: 'organization config file'
+    })
+  };
+
+  async run() {
+    const { flags } = this.parse(this.constructor as typeof CreateOrganisation);
+    const { organizationConfig, auth } = flags;
+    const environment = await this.readEnvironmentFile();
+
+    const organizationConfigFile = await this.readConfigFromFile(
+      OrganizationConfig,
+      organizationConfig
+    );
+    const authConfig = await this.readConfigFromFile(AuthConfig, auth);
+
+    if (!authConfig) {
+      this.error('Valid auth config file must be supplied');
+    }
+    if (!organizationConfigFile) {
+      this.error('Valid organization config file must be supplied');
+    }
+    try {
+      const result = await vaultAPIFactory(environment)(
+        authConfig
+      ).OrganizationsManagingOrganizationsApi.organizationsPost(
+        organizationConfigFile.organization
+      );
+      this.printYaml(OrganizationConfig.encodeFromJSON(result.organization));
+    } catch (err) {
+      await this.handleException(err);
+    }
+  }
+}

--- a/packages/cli/src/configs/organization-config.ts
+++ b/packages/cli/src/configs/organization-config.ts
@@ -1,0 +1,33 @@
+import { Organization, PostOrganizationRequest } from '@meeco/vault-api-sdk';
+import { CLIError } from '@oclif/errors';
+import { ConfigReader, IYamlConfig } from './yaml-config';
+
+export interface IOrganizationMetadata {}
+
+export interface IOrganizationTemplate extends PostOrganizationRequest {}
+
+@ConfigReader<OrganizationConfig>()
+export class OrganizationConfig {
+  static kind = 'Organization';
+
+  constructor(public readonly organization: IOrganizationTemplate) {}
+
+  static fromYamlConfig(
+    yamlConfigObj: IYamlConfig<IOrganizationMetadata, IOrganizationTemplate>
+  ): OrganizationConfig {
+    if (yamlConfigObj.kind !== OrganizationConfig.kind) {
+      throw new CLIError(
+        `Config file of incorrect kind: '${yamlConfigObj.kind}' (expected '${OrganizationConfig.kind}')`
+      );
+    }
+
+    return new OrganizationConfig(yamlConfigObj.spec);
+  }
+
+  static encodeFromJSON(json: Organization) {
+    return {
+      kind: OrganizationConfig.kind,
+      spec: json
+    };
+  }
+}

--- a/packages/cli/test/commands/organizations/create.test.ts
+++ b/packages/cli/test/commands/organizations/create.test.ts
@@ -1,0 +1,57 @@
+import { expect } from 'chai';
+import { readFileSync } from 'fs';
+import {
+  customTest,
+  inputFixture,
+  outputFixture,
+  testEnvironmentFile,
+  testUserAuth
+} from '../../test-helpers';
+
+describe('organizations:create', () => {
+  customTest
+    .stdout()
+    .stderr()
+    .mockCryppo()
+    .nock('https://sandbox.meeco.me/vault', mockVault)
+    .run([
+      'organizations:create',
+      ...testUserAuth,
+      ...testEnvironmentFile,
+      '-c',
+      inputFixture('create-organization.input.yaml')
+    ])
+    .it('Requests the creation of a new organization', ctx => {
+      const expected = readFileSync(outputFixture('create-organization.output.yaml'), 'utf-8');
+      expect(ctx.stdout.trim()).to.contain(expected.trim());
+    });
+});
+
+const response = {
+  organization: {
+    id: '00000000-0000-0000-0000-000000000000',
+    name: 'SuperData Inc.',
+    description: 'My super data handling organization',
+    url: 'https://superdata.example.com',
+    email: 'admin@superdata.example.com',
+    status: 'requested',
+    requestor_id: '00000000-0000-0000-0000-000000000000',
+    validated_by_id: null,
+    agent_id: null,
+    validated_at: null,
+    created_at: '2020-06-23T08:38:32.915Z'
+  }
+};
+
+function mockVault(api) {
+  api
+    .post('/organizations', {
+      name: 'SuperData Inc.',
+      description: 'My super data handling organization',
+      url: 'https://superdata.example.com',
+      email: 'admin@superdata.example.com'
+    })
+    .matchHeader('Authorization', '2FPN4n5T68xy78i6HHuQ')
+    .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
+    .reply(200, response);
+}

--- a/packages/cli/test/fixtures/inputs/create-organization.input.yaml
+++ b/packages/cli/test/fixtures/inputs/create-organization.input.yaml
@@ -1,0 +1,7 @@
+kind: Organization
+metadata:
+spec:
+  name: SuperData Inc.
+  description: My super data handling organization
+  url: https://superdata.example.com
+  email: admin@superdata.example.com

--- a/packages/cli/test/fixtures/outputs/create-organization.output.yaml
+++ b/packages/cli/test/fixtures/outputs/create-organization.output.yaml
@@ -1,0 +1,13 @@
+kind: Organization
+spec:
+  id: 00000000-0000-0000-0000-000000000000
+  name: SuperData Inc.
+  description: My super data handling organization
+  url: https://superdata.example.com
+  email: admin@superdata.example.com
+  status: requested
+  requestor_id: 00000000-0000-0000-0000-000000000000
+  validated_by_id: null
+  agent_id: null
+  validated_at: null
+  created_at: 2020-06-23T08:38:32.915Z

--- a/tslint.json
+++ b/tslint.json
@@ -26,6 +26,7 @@
       }
     ],
     "no-string-literal": false,
+    "no-empty-interface": false,
     "no-empty": [false],
     "quotemark": [true, "single"],
     "trailing-comma": [false],


### PR DESCRIPTION
Adds a new `meeco organizations:create` command under a new `organizations` scope.

The yaml config file for an organization looks as follows:

```yaml
kind: Organization
metadata:
spec:
  name: SuperData Inc.
  description: My super data handling organization
  url: https://superdata.example.com
  email: admin@superdata.example.com
```

This results in an output like the following:

```yaml
kind: Organization
spec:
  id: 00000000-0000-0000-0000-000000000000
  name: SuperData Inc.
  description: My super data handling organization
  url: https://superdata.example.com
  email: admin@superdata.example.com
  status: requested
  requestor_id: 00000000-0000-0000-0000-000000000000
  validated_by_id: null
  agent_id: null
  validated_at: null
  created_at: 2020-06-23T08:38:32.915Z
```

No functionality was added to the SDK as this can be done through an simple call to the existing swagger SDK so adding to the Meeco SDK adds no real value.