### PR TITLE
Automatically generate documentation in Github Actions

### DIFF
--- a/.github/workflows/update-documentation.yaml
+++ b/.github/workflows/update-documentation.yaml
@@ -1,0 +1,38 @@
+name: Update Documentation
+
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npx lerna bootstrap --hoist
+      - run: npm run docs
+      - name: Deploy SDK docs to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs
+      - name: Push OCLIF Generated CLI Readme
+        uses: EndBug/add-and-commit@v4
+        # https://github.com/marketplace/actions/add-commit
+        with:
+          add: 'packages/cli/README.md'
+          author_name: github-actions[bot]
+          author_email: noreply@github.com'
+          message: 'Auto-update CLI documentation'
+        env:
+          # This is necessary in order to push a commit to the repo
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Leave this line unchanged

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "scripts": {
     "alias": "alias meeco=\"node --inspect --require tsconfig-paths/register ./packages/cli/bin/run\"",
     "bootstrap": "lerna bootstrap --hoist",
+    "build": "lerna run build",
     "docs": "lerna run docs",
-    "test": "lerna run test",
-    "build": "lerna run build"
+    "postinstall": "npm run bootstrap",
+    "test": "lerna run test"
   },
   "devDependencies": {
     "lerna": "^3.22.0"


### PR DESCRIPTION
This PR *should* (I haven't tested because it runs on master):

Whenever there is a commit on master:
1. Build the TypeDoc SDK docs
2. Commit them to the gh-pages branch (which we would update github to use for the github io page)
3. Generate the automated OCLIF Readme updates
4. Commit those back to master (which should not trigger another build because of the way `GITHUB_TOKEN` works)

I also added lerna bootstrap to postinstall to hopefully avoid confusion in future for those not familiar with lerna projects.