### PR TITLE
Fix issue where templates:info and items:create-config would error

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -862,10 +862,14 @@ USAGE
   $ meeco templates:info TEMPLATENAME
 
 OPTIONS
-  -a, --auth=auth                (required) [default: .user.yaml] Authorization config file yaml file (if not using the
-                                 default .user.yaml)
+  -a, --auth=auth                                  (required) [default: .user.yaml] Authorization config file yaml file
+                                                   (if not using the default .user.yaml)
 
-  -e, --environment=environment  [default: .environment.yaml] environment config file
+  -e, --environment=environment                    [default: .environment.yaml] environment config file
+
+  -n, --classificationName=classificationName      Scope templates to a particular classification name
+
+  -s, --classificationScheme=classificationScheme  Scope templates to a particular classification scheme
 
 EXAMPLE
   meeco templates:info password

--- a/packages/cli/src/commands/templates/list.ts
+++ b/packages/cli/src/commands/templates/list.ts
@@ -1,4 +1,4 @@
-import { TemplatesService } from '@meeco/sdk';
+import { vaultAPIFactory } from '@meeco/sdk';
 import { flags as _flags } from '@oclif/command';
 import { cli } from 'cli-ux';
 import { AuthConfig } from '../../configs/auth-config';
@@ -32,9 +32,9 @@ export default class TemplatesList extends MeecoCommand {
       const { auth, classificationName, classificationScheme } = flags;
       const environment = await this.readEnvironmentFile();
       const authConfig = await this.readConfigFromFile(AuthConfig, auth);
-      const service = new TemplatesService(environment, authConfig!.vault_access_token);
+      const service = vaultAPIFactory(environment)(authConfig).ItemTemplateApi;
       cli.action.start('Fetching available templates');
-      const templates = await service.listTemplates(classificationScheme!, classificationName!);
+      const templates = await service.itemTemplatesGet(classificationScheme, classificationName);
       cli.action.stop();
       this.printYaml(TemplateConfig.encodeListFromJSON(templates));
     } catch (err) {

--- a/packages/cli/src/configs/template-config.ts
+++ b/packages/cli/src/configs/template-config.ts
@@ -5,7 +5,22 @@ export class TemplateConfig {
   static readonly kind = 'Template';
   static readonly pluralKind = 'Templates';
 
-  static encodeFromJSON(json: ITemplateData) {
+  static encodeFromJSON(json: ITemplateData | ITemplateData[]) {
+    if (Array.isArray(json) && json.length > 1) {
+      return {
+        kind: TemplateConfig.pluralKind,
+        spec: json.map(template => ({
+          ...template,
+          slots: template.slots
+        }))
+      };
+    }
+
+    if (Array.isArray(json)) {
+      // Single result - just use it.
+      json = json[0];
+    }
+
     return {
       kind: TemplateConfig.kind,
       spec: {

--- a/packages/cli/test/commands/items/create-config.test.ts
+++ b/packages/cli/test/commands/items/create-config.test.ts
@@ -1,9 +1,5 @@
 import { expect } from '@oclif/test';
 import { readFileSync } from 'fs';
-import {
-  DEFAULT_CLASSIFICATION_NAME,
-  DEFAULT_CLASSIFICATION_SCHEME
-} from '../../../src/util/constants';
 import { customTest, outputFixture, testEnvironmentFile, testUserAuth } from '../../test-helpers';
 
 describe('items:create-config', () => {
@@ -59,10 +55,6 @@ const response = {
 function mockVault(api) {
   api
     .get('/item_templates')
-    .query({
-      'by_classification[scheme]': DEFAULT_CLASSIFICATION_SCHEME,
-      'by_classification[name]': DEFAULT_CLASSIFICATION_NAME
-    })
     .matchHeader('Authorization', '2FPN4n5T68xy78i6HHuQ')
     .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
     .reply(200, response);

--- a/packages/cli/test/commands/templates/info.test.ts
+++ b/packages/cli/test/commands/templates/info.test.ts
@@ -1,9 +1,5 @@
 import { expect } from '@oclif/test';
 import { readFileSync } from 'fs';
-import {
-  DEFAULT_CLASSIFICATION_NAME,
-  DEFAULT_CLASSIFICATION_SCHEME
-} from '../../../src/util/constants';
 import { customTest, outputFixture, testEnvironmentFile, testUserAuth } from '../../test-helpers';
 
 describe('templates:info', () => {
@@ -13,10 +9,6 @@ describe('templates:info', () => {
     .nock('https://sandbox.meeco.me/vault', api => {
       api
         .get('/item_templates')
-        .query({
-          'by_classification[scheme]': DEFAULT_CLASSIFICATION_SCHEME,
-          'by_classification[name]': DEFAULT_CLASSIFICATION_NAME
-        })
         .matchHeader('Authorization', '2FPN4n5T68xy78i6HHuQ')
         .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
         .reply(200, response);

--- a/packages/sdk/src/services/templates-service.ts
+++ b/packages/sdk/src/services/templates-service.ts
@@ -6,6 +6,8 @@ import { vaultAPIFactory } from '../util/api-factory';
 
 /**
  * List and fetch available templates for Meeco Items from the API.
+ *
+ * @deprecated Use [vaultApiFactory] ItemTemplateApi list instead.
  */
 export class TemplatesService {
   private api: ItemTemplateApi;
@@ -18,6 +20,9 @@ export class TemplatesService {
     return await this.api.itemTemplatesGet(classificationScheme, classificationName);
   }
 
+  /**
+   * @deprecated Use [vaultApiFactory] ItemTemplateApi list or get by id instead.
+   */
   public async getTemplate(
     classificationScheme: string,
     classificationName: string,
@@ -31,8 +36,8 @@ export class TemplatesService {
       );
     }
     const slots = result.slots?.filter(slot => template.slot_ids?.includes(slot.id!));
-    const classification_nodes = result.classification_nodes.filter(classifcationNode =>
-      template.classification_node_ids.includes(classifcationNode.id)
+    const classification_nodes = result.classification_nodes.filter(classificationNode =>
+      template.classification_node_ids.includes(classificationNode.id)
     );
 
     return {


### PR DESCRIPTION
Fixes some current issues with these commands since changing `templates:list` to not use default template name and scheme.

- Use vault api sdk's instead of template service as it did not add value
- Handle cases where multiple templates of same name might exist
- Remove default template classification scheme from above commands
- Allow specifying scheme and name to above commands