### PR TITLE
Upgrade cryppo to 0.6.2; Use local version of Buffer lib

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -10,7 +10,7 @@
   "bugs": "https://github.com/Meeco/cli/issues",
   "dependencies": {
     "@meeco/sdk": "0.0.11-beta",
-    "@meeco/cryppo": "^0.6.0",
+    "@meeco/cryppo": "^0.6.2",
     "@meeco/keystore-api-sdk": "0.14.1-beta.0",
     "@meeco/vault-api-sdk": "0.19.1-beta.0",
     "@oclif/command": "^1.5.19",

--- a/packages/cli/test/e2e.sh
+++ b/packages/cli/test/e2e.sh
@@ -8,7 +8,7 @@ run users:create -p supersecretpassword > .Alice.yaml
 echo "Fetch template list"
 run templates:list -a .Alice.yaml
 echo "Create a 'Vehicle' card template for 'Alice'"
-run items:create-config ng_vehicle -a .Alice.yaml > .template_vehicle.yaml
+run items:create-config vehicle -a .Alice.yaml > .template_vehicle.yaml
 sed '5,6 s/label: ""/label: "My Vehicle"/' .template_vehicle.yaml > .my_vehicle.yaml
 echo "Create a 'Vehicle' card for 'Alice'"
 run items:create -i .my_vehicle.yaml -a .Alice.yaml

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -9,11 +9,12 @@
   "module": "dist/index.esm.js",
   "types": "dist/index.d.ts",
   "dependencies": {
-    "@meeco/cryppo": "^0.6.0",
+    "@meeco/cryppo": "^0.6.2",
     "@meeco/keystore-api-sdk": "0.14.1-beta.0",
     "@meeco/vault-api-sdk": "0.19.1-beta.0",
     "@types/node-forge": "~0.9.0",
     "base-x": "~3.0.7",
+    "buffer": "5.6.0",
     "chalk": "^4.0.0",
     "debug": "^4.1.1",
     "form-data": "^3.0.0",

--- a/packages/sdk/src/services/item-service.ts
+++ b/packages/sdk/src/services/item-service.ts
@@ -1,4 +1,5 @@
 import { AttachmentResponse, Slot, ThumbnailResponse } from '@meeco/vault-api-sdk';
+import { Buffer as _buffer } from 'buffer';
 import * as Jimp from 'jimp';
 import { AuthData } from '../models/auth-data';
 import { EncryptionKey } from '../models/encryption-key';
@@ -102,7 +103,7 @@ export class ItemService {
       const blob =
         typeof Blob === 'function'
           ? new Blob([encryptedThumbnail.serialized])
-          : Buffer.from(encryptedThumbnail.serialized, 'binary');
+          : _buffer.from(encryptedThumbnail.serialized, 'binary');
       response = await this.vaultAPIFactory(auth).ThumbnailApi.thumbnailsPost(
         blob as any,
         binaryId,
@@ -144,7 +145,7 @@ export class ItemService {
       const blob =
         typeof Blob === 'function'
           ? new Blob([encryptedFile.serialized])
-          : Buffer.from(encryptedFile.serialized, 'binary');
+          : _buffer.from(encryptedFile.serialized, 'binary');
       uploadedBinary = await this.vaultAPIFactory(
         auth.vault_access_token
       ).AttachmentApi.attachmentsPost(blob as any, fileName, fileType);

--- a/packages/sdk/src/services/secret-service.ts
+++ b/packages/sdk/src/services/secret-service.ts
@@ -1,5 +1,6 @@
 // tslint:disable-next-line: no-var-requires
 const baseX = require('base-x');
+import { Buffer as _buffer } from 'buffer';
 import { ERROR_CODES, MeecoServiceError } from '../models/service-error';
 import cryppo from './cryppo-service';
 
@@ -54,7 +55,7 @@ export class SecretService {
   public encodeBase58(val: string | Buffer) {
     // https://tools.ietf.org/html/draft-msporny-base58-01
     const ALPHABET = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
-    const input = val instanceof Buffer ? val : Buffer.from(val, 'binary');
+    const input = val instanceof Buffer ? val : _buffer.from(val, 'binary');
     return baseX(ALPHABET).encode(input);
   }
 


### PR DESCRIPTION
Cryppo upgraded to 0.6.2
Global use of Buffer replaced with `buffer` library