### PR TITLE
Fix error when share owner fetches the share

### DIFF
--- a/packages/cli/test/e2e.sh
+++ b/packages/cli/test/e2e.sh
@@ -28,3 +28,5 @@ echo "Fetch shared cards as 'Bob'"
 shareId=`run shares:list -a .Bob.yaml | awk '/^  - share_id: / {print $3}'`
 echo "Fetch one shard card as Bob"
 run shares:get $shareId -a .Bob.yaml
+echo "Fetch same shared card as 'Alice'"
+run shares:get $shareId -a .Alice.yaml


### PR DESCRIPTION
This pull requests fixes the error when share owner fetches the share himself. 
Instead of connection key, user data encryption key has to be used for slot decryption.
Result of such call is all item information (not just the shared slots).