### PR TITLE
Install and configure the storybook docs plugin

### DIFF
--- a/packages/style-kit/.storybook/main.js
+++ b/packages/style-kit/.storybook/main.js
@@ -2,8 +2,8 @@ const path = require('path');
 
 module.exports = {
   // this dirname is because we run tests from project root
-  stories: ['../stories/*.stories.*'],
-  addons: ['@storybook/addon-storysource', '@storybook/addon-knobs'],
+  stories: ['../stories/*.stories.(ts|js)'],
+  addons: ['@storybook/addon-storysource', '@storybook/addon-knobs', '@storybook/addon-docs'],
   logLevel: 'debug',
   webpackFinal: async (config, { configType }) => {
     // `configType` has a value of 'DEVELOPMENT' or 'PRODUCTION'

--- a/packages/style-kit/package.json
+++ b/packages/style-kit/package.json
@@ -22,6 +22,7 @@
     "@babel/core": "^7.10.3",
     "@cypress/skip-test": "^2.5.0",
     "@storybook/addon-actions": "^5.3.19",
+    "@storybook/addon-docs": "^5.3.19",
     "@storybook/addon-knobs": "^5.3.19",
     "@storybook/addon-storysource": "^5.3.19",
     "@storybook/addons": "^5.3.19",

--- a/packages/style-kit/stories/avatar.mdx
+++ b/packages/style-kit/stories/avatar.mdx
@@ -1,0 +1,4 @@
+
+# Avatar
+
+This is an example docs page

--- a/packages/style-kit/stories/avatar.stories.js
+++ b/packages/style-kit/stories/avatar.stories.js
@@ -1,6 +1,15 @@
-export default { title: 'Avatar' };
+import mdx from './avatar.mdx';
 import { story } from 'style-loader!./avatar.stories.scss';
 import avatarImg from '../assets/avatar-img.png';
+
+export default {
+  title: 'Avatar',
+  parameters: {
+    docs: {
+      page: mdx
+    }
+  }
+};
 
 export const avatar = () =>
   /*html*/


### PR DESCRIPTION
Default is to just render the stories with a heading:

![image](https://user-images.githubusercontent.com/9100419/89001990-1362e180-d33b-11ea-8fcb-bb7fef03952b.png)


When an mdx file is configured it renders that instead:

![image](https://user-images.githubusercontent.com/9100419/89001972-034b0200-d33b-11ea-99f0-58a062a467dd.png)
