### PR TITLE
Add chalk as dependency to fix bootstrap

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "test": "lerna run test"
   },
   "devDependencies": {
+    "chalk": "^4.0.0",
     "cypress": "^4.9.0",
     "lerna": "^3.22.0"
   }


### PR DESCRIPTION
`npm run bootstrap` fails with missing `chalk` dependency. This PR adds the dependency.