### PR TITLE
Add the ability to override loggers on services after construction

### DIFF
--- a/packages/sdk/src/services/connection-service.ts
+++ b/packages/sdk/src/services/connection-service.ts
@@ -10,6 +10,7 @@ import {
   vaultAPIFactory
 } from '../util/api-factory';
 import { findConnectionBetween } from '../util/find-connection-between';
+import { Logger, noopLogger } from '../util/logger';
 
 /**
  * Used for setting up connections between Meeco `User`s to allow the secure sharing of data (see also {@link ShareService})
@@ -18,9 +19,14 @@ export class ConnectionService {
   private cryppo = (<any>global).cryppo || cryppo;
   private vaultApiFactory: VaultAPIFactory;
   private keystoreApiFactory: KeystoreAPIFactory;
-  constructor(private environment: Environment, private log: (message: string) => void = () => {}) {
+
+  constructor(private environment: Environment, private log: Logger = noopLogger) {
     this.vaultApiFactory = vaultAPIFactory(environment);
     this.keystoreApiFactory = keystoreAPIFactory(environment);
+  }
+
+  public setLogger(logger: Logger) {
+    this.log = logger;
   }
 
   public async createInvitation(name: string, auth: AuthData) {

--- a/packages/sdk/src/services/item-service.ts
+++ b/packages/sdk/src/services/item-service.ts
@@ -11,6 +11,7 @@ import { DecryptedSlot } from '../models/local-slot';
 import { MeecoServiceError } from '../models/service-error';
 import cryppo from '../services/cryppo-service';
 import { VaultAPIFactory, vaultAPIFactory } from '../util/api-factory';
+import { Logger, noopLogger } from '../util/logger';
 
 /**
  * Used for fetching and sending `Items` to and from the Vault.
@@ -19,7 +20,7 @@ export class ItemService {
   private static cryppo = (<any>global).cryppo || cryppo;
   private vaultAPIFactory: VaultAPIFactory;
 
-  constructor(environment: Environment, private log: (message: string) => void = () => {}) {
+  constructor(environment: Environment, private log: Logger = noopLogger) {
     this.vaultAPIFactory = vaultAPIFactory(environment);
   }
 
@@ -47,6 +48,10 @@ export class ItemService {
         return decrypted;
       })
     );
+  }
+
+  public setLogger(logger: Logger) {
+    this.log = logger;
   }
 
   public async create(vaultAccessToken: string, dek: EncryptionKey, config: ItemCreateData) {

--- a/packages/sdk/src/services/organization-members-service.ts
+++ b/packages/sdk/src/services/organization-members-service.ts
@@ -1,5 +1,6 @@
 import { Environment } from '../models/environment';
 import { vaultAPIFactory, VaultAPIFactory } from '../util/api-factory';
+import { Logger, noopLogger } from '../util/logger';
 import cryppo from './cryppo-service';
 /**
  * Manage organization members from the API.
@@ -10,8 +11,12 @@ export class OrganizationMembersService {
   // for mocking during testing
   private cryppo = (<any>global).cryppo || cryppo;
 
-  constructor(environment: Environment, private log: (message: string) => void = () => {}) {
+  constructor(environment: Environment, private log: Logger = noopLogger) {
     this.vaultApiFactory = vaultAPIFactory(environment);
+  }
+
+  public setLogger(logger: Logger) {
+    this.log = logger;
   }
 
   public async createInvite(

--- a/packages/sdk/src/services/share-service.ts
+++ b/packages/sdk/src/services/share-service.ts
@@ -12,6 +12,7 @@ import {
   VaultAPIFactory
 } from '../util/api-factory';
 import { fetchConnectionWithId } from '../util/find-connection-between';
+import { Logger, noopLogger } from '../util/logger';
 import cryppo from './cryppo-service';
 import { ItemService } from './item-service';
 
@@ -45,9 +46,13 @@ export class ShareService {
   private keystoreApiFactory: KeystoreAPIFactory;
   private vaultApiFactory: VaultAPIFactory;
 
-  constructor(private environment: Environment, private log: (message: string) => void = () => {}) {
+  constructor(private environment: Environment, private log: Logger = noopLogger) {
     this.keystoreApiFactory = keystoreAPIFactory(environment);
     this.vaultApiFactory = vaultAPIFactory(environment);
+  }
+
+  public setLogger(logger: Logger) {
+    this.log = logger;
   }
 
   public async shareItem(

--- a/packages/sdk/src/util/logger.ts
+++ b/packages/sdk/src/util/logger.ts
@@ -1,0 +1,2 @@
+export type Logger = (message: string) => void;
+export const noopLogger = () => {};


### PR DESCRIPTION
There may be instances where we want to change the logger - e.g. in an environment that uses Dependency Injection, we may want to get an instance of `UserService` from DI but bind the logging to a local instance method.

This will support that.