### PR TITLE
set the baseUrl of the file-storage-browser build to be inside

### DIFF
--- a/packages/file-storage-browser/tsconfig.json
+++ b/packages/file-storage-browser/tsconfig.json
@@ -6,7 +6,8 @@
     "forceConsistentCasingInFileNames": true,
     "declaration": true,
     "outDir": "./lib",
-    "noImplicitAny": false
+    "noImplicitAny": false,
+    "baseUrl": "./"
   },
   "include": ["./src"]
 }


### PR DESCRIPTION
set the baseUrl of the file-storage-browser build to be inside the package's directory not at the root of the monorepo