### PR TITLE
Feature/user login commands

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -246,6 +246,8 @@ once approved it can be access with follwoing command
 - [`meeco templates:list`](#meeco-templateslist)
 - [`meeco users:create`](#meeco-userscreate)
 - [`meeco users:get`](#meeco-usersget)
+- [`meeco users:login`](#meeco-userslogin)
+- [`meeco users:logout`](#meeco-userslogout)
 
 ## `meeco client-task-queue:list`
 
@@ -256,18 +258,23 @@ USAGE
   $ meeco client-task-queue:list
 
 OPTIONS
-  -a, --auth=auth                              (required) [default: .user.yaml] Authorization config file yaml file (if
+  -a, --auth=auth                              (required) [default: .user.yaml]
+                                               Authorization config yaml file (if
                                                not using the default .user.yaml)
 
-  -e, --environment=environment                [default: .environment.yaml] environment config file
+  -e, --environment=environment                [default: .environment.yaml]
+                                               environment config file
 
-  -s, --state=state                            [default: Todo] Client Task Queue avalible states:
+  -s, --state=state                            [default: Todo] Client Task Queue
+                                               avalible states:
                                                Todo,InProgress,Done,Failed
 
-  --all                                        Get all possible results from web API, possibly with multiple calls.
+  --all                                        Get all possible results from web
+                                               API, possibly with multiple calls.
 
-  --supressChangingState=supressChangingState  [default: true] suppress transitioning tasks in the response to
-                                               in_progress: true, false
+  --supressChangingState=supressChangingState  [default: true] suppress
+                                               transitioning tasks in the response
+                                               to in_progress: true, false
 
 EXAMPLE
   meeco client-task-queue:list -a path/to/auth.yaml
@@ -284,8 +291,11 @@ USAGE
   $ meeco connections:create
 
 OPTIONS
-  -c, --config=config            (required) Connection config file to use for the creation
-  -e, --environment=environment  [default: .environment.yaml] environment config file
+  -c, --config=config            (required) Connection config file to use for the
+                                 creation
+
+  -e, --environment=environment  [default: .environment.yaml] environment config
+                                 file
 ```
 
 _See code: [src/commands/connections/create.ts](https://github.com/Meeco/cli/blob/master/src/commands/connections/create.ts)_
@@ -299,8 +309,11 @@ USAGE
   $ meeco connections:create-config
 
 OPTIONS
-  -e, --environment=environment  [default: .environment.yaml] environment config file
+  -e, --environment=environment  [default: .environment.yaml] environment config
+                                 file
+
   -f, --from=from                (required) User config file for the 'from' user
+
   -t, --to=to                    (required) User config file for the 'to' user
 ```
 
@@ -315,12 +328,15 @@ USAGE
   $ meeco connections:list
 
 OPTIONS
-  -a, --auth=auth                (required) [default: .user.yaml] Authorization config file yaml file (if not using the
-                                 default .user.yaml)
+  -a, --auth=auth                (required) [default: .user.yaml] Authorization
+                                 config yaml file (if not using the default
+                                 .user.yaml)
 
-  -e, --environment=environment  [default: .environment.yaml] environment config file
+  -e, --environment=environment  [default: .environment.yaml] environment config
+                                 file
 
-  --all                          Get all possible results from web API, possibly with multiple calls.
+  --all                          Get all possible results from web API, possibly
+                                 with multiple calls.
 ```
 
 _See code: [src/commands/connections/list.ts](https://github.com/Meeco/cli/blob/master/src/commands/connections/list.ts)_
@@ -351,12 +367,14 @@ USAGE
   $ meeco items:attach-file
 
 OPTIONS
-  -a, --auth=auth                (required) [default: .user.yaml] Authorization config file yaml file (if not using the
-                                 default .user.yaml)
+  -a, --auth=auth                (required) [default: .user.yaml] Authorization
+                                 config yaml file (if not using the default
+                                 .user.yaml)
 
   -c, --config=config            (required) file attachment config yaml
 
-  -e, --environment=environment  [default: .environment.yaml] environment config file
+  -e, --environment=environment  [default: .environment.yaml] environment config
+                                 file
 
 EXAMPLES
   meeco items:attach-file -c ./file-attachment-config.yaml
@@ -373,10 +391,12 @@ USAGE
   $ meeco items:create
 
 OPTIONS
-  -a, --auth=auth                (required) [default: .user.yaml] Authorization config file yaml file (if not using the
-                                 default .user.yaml)
+  -a, --auth=auth                (required) [default: .user.yaml] Authorization
+                                 config yaml file (if not using the default
+                                 .user.yaml)
 
-  -e, --environment=environment  [default: .environment.yaml] environment config file
+  -e, --environment=environment  [default: .environment.yaml] environment config
+                                 file
 
   -i, --item=item                (required) item yaml file
 
@@ -398,14 +418,19 @@ ARGUMENTS
   TEMPLATENAME  Name of the template to use for the item
 
 OPTIONS
-  -a, --auth=auth                                  (required) [default: .user.yaml] Authorization config file yaml file
-                                                   (if not using the default .user.yaml)
+  -a, --auth=auth                                  (required) [default: .user.yaml]
+                                                   Authorization config yaml file
+                                                   (if not using the default
+                                                   .user.yaml)
 
-  -e, --environment=environment                    [default: .environment.yaml] environment config file
+  -e, --environment=environment                    [default: .environment.yaml]
+                                                   environment config file
 
-  -n, --classificationName=classificationName      Scope templates to a particular classification name
+  -n, --classificationName=classificationName      Scope templates to a particular
+                                                   classification name
 
-  -s, --classificationScheme=classificationScheme  Scope templates to a particular classification scheme
+  -s, --classificationScheme=classificationScheme  Scope templates to a particular
+                                                   classification scheme
 
 EXAMPLES
   meeco items:create-config password
@@ -422,10 +447,12 @@ USAGE
   $ meeco items:get ITEMID
 
 OPTIONS
-  -a, --auth=auth                (required) [default: .user.yaml] Authorization config file yaml file (if not using the
-                                 default .user.yaml)
+  -a, --auth=auth                (required) [default: .user.yaml] Authorization
+                                 config yaml file (if not using the default
+                                 .user.yaml)
 
-  -e, --environment=environment  [default: .environment.yaml] environment config file
+  -e, --environment=environment  [default: .environment.yaml] environment config
+                                 file
 ```
 
 _See code: [src/commands/items/get.ts](https://github.com/Meeco/cli/blob/master/src/commands/items/get.ts)_
@@ -442,10 +469,12 @@ ARGUMENTS
   ATTACHMENTID  ID of the attachment to download
 
 OPTIONS
-  -a, --auth=auth                (required) [default: .user.yaml] Authorization config file yaml file (if not using the
-                                 default .user.yaml)
+  -a, --auth=auth                (required) [default: .user.yaml] Authorization
+                                 config yaml file (if not using the default
+                                 .user.yaml)
 
-  -e, --environment=environment  [default: .environment.yaml] environment config file
+  -e, --environment=environment  [default: .environment.yaml] environment config
+                                 file
 
   -o, --outputPath=outputPath    (required) output file path
 
@@ -467,10 +496,12 @@ ARGUMENTS
   THUMBNAILID  ID of the thumbnail to download
 
 OPTIONS
-  -a, --auth=auth                (required) [default: .user.yaml] Authorization config file yaml file (if not using the
-                                 default .user.yaml)
+  -a, --auth=auth                (required) [default: .user.yaml] Authorization
+                                 config yaml file (if not using the default
+                                 .user.yaml)
 
-  -e, --environment=environment  [default: .environment.yaml] environment config file
+  -e, --environment=environment  [default: .environment.yaml] environment config
+                                 file
 
   -o, --outputPath=outputPath    (required) output file path
 
@@ -489,12 +520,15 @@ USAGE
   $ meeco items:list
 
 OPTIONS
-  -a, --auth=auth                (required) [default: .user.yaml] Authorization config file yaml file (if not using the
-                                 default .user.yaml)
+  -a, --auth=auth                (required) [default: .user.yaml] Authorization
+                                 config yaml file (if not using the default
+                                 .user.yaml)
 
-  -e, --environment=environment  [default: .environment.yaml] environment config file
+  -e, --environment=environment  [default: .environment.yaml] environment config
+                                 file
 
-  --all                          Get all possible results from web API, possibly with multiple calls.
+  --all                          Get all possible results from web API, possibly
+                                 with multiple calls.
 
 EXAMPLE
   meeco items:list -a path/to/auth.yaml
@@ -511,10 +545,12 @@ USAGE
   $ meeco items:remove-slot SLOTID
 
 OPTIONS
-  -a, --auth=auth                (required) [default: .user.yaml] Authorization config file yaml file (if not using the
-                                 default .user.yaml)
+  -a, --auth=auth                (required) [default: .user.yaml] Authorization
+                                 config yaml file (if not using the default
+                                 .user.yaml)
 
-  -e, --environment=environment  [default: .environment.yaml] environment config file
+  -e, --environment=environment  [default: .environment.yaml] environment config
+                                 file
 
 EXAMPLES
   meeco items:remove-slot slotId
@@ -531,10 +567,12 @@ USAGE
   $ meeco items:update
 
 OPTIONS
-  -a, --auth=auth                (required) [default: .user.yaml] Authorization config file yaml file (if not using the
-                                 default .user.yaml)
+  -a, --auth=auth                (required) [default: .user.yaml] Authorization
+                                 config yaml file (if not using the default
+                                 .user.yaml)
 
-  -e, --environment=environment  [default: .environment.yaml] environment config file
+  -e, --environment=environment  [default: .environment.yaml] environment config
+                                 file
 
   -i, --item=item                (required) item yaml file
 ```
@@ -550,16 +588,18 @@ USAGE
   $ meeco organization-members:accept-invitation
 
 OPTIONS
-  -a, --auth=auth                          (required) [default: .user.yaml] Authorization config file yaml file (if not
+  -a, --auth=auth                          (required) [default: .user.yaml]
+                                           Authorization config yaml file (if not
                                            using the default .user.yaml)
 
-  -e, --environment=environment            [default: .environment.yaml] environment config file
+  -e, --environment=environment            [default: .environment.yaml] environment
+                                           config file
 
   -i, --invitationConfig=invitationConfig  (required) member invitation yaml file
 
 EXAMPLE
-  meeco organization-members:accpet-invitation -i .my-member-invitation.yaml -a .user_2.yaml >
-  .my-org-member-connection.yaml
+  meeco organization-members:accpet-invitation -i .my-member-invitation.yaml -a
+  .user_2.yaml > .my-org-member-connection.yaml
 ```
 
 _See code: [src/commands/organization-members/accept-invitation.ts](https://github.com/Meeco/cli/blob/master/src/commands/organization-members/accept-invitation.ts)_
@@ -576,16 +616,18 @@ ARGUMENTS
   MEMBER_ROLE  [default: admin] Organization member avalible roles: Admin,Owner
 
 OPTIONS
-  -a, --auth=auth                (required) [default: .user.yaml] Authorization config file yaml file (if not using the
-                                 default .user.yaml)
+  -a, --auth=auth                (required) [default: .user.yaml] Authorization
+                                 config yaml file (if not using the default
+                                 .user.yaml)
 
-  -e, --environment=environment  [default: .environment.yaml] environment config file
+  -e, --environment=environment  [default: .environment.yaml] environment config
+                                 file
 
   -o, --org=org                  (required) organization yaml file
 
 EXAMPLE
-  meeco organization-members:crate-invitation -o .my-created-organization.yaml -a .my-org-login.yaml >
-  .my-org-member-invitation.yaml
+  meeco organization-members:crate-invitation -o .my-created-organization.yaml -a
+  .my-org-login.yaml > .my-org-member-invitation.yaml
 ```
 
 _See code: [src/commands/organization-members/create-invitation.ts](https://github.com/Meeco/cli/blob/master/src/commands/organization-members/create-invitation.ts)_
@@ -603,10 +645,12 @@ ARGUMENTS
   ID               user ID of the Member
 
 OPTIONS
-  -a, --auth=auth                (required) [default: .user.yaml] Authorization config file yaml file (if not using the
-                                 default .user.yaml)
+  -a, --auth=auth                (required) [default: .user.yaml] Authorization
+                                 config yaml file (if not using the default
+                                 .user.yaml)
 
-  -e, --environment=environment  [default: .environment.yaml] environment config file
+  -e, --environment=environment  [default: .environment.yaml] environment config
+                                 file
 
 EXAMPLE
   meeco organization-members:delete <organization_id> <id>
@@ -623,12 +667,15 @@ USAGE
   $ meeco organization-members:list ORGANIZATION_ID
 
 OPTIONS
-  -a, --auth=auth                (required) [default: .user.yaml] Authorization config file yaml file (if not using the
-                                 default .user.yaml)
+  -a, --auth=auth                (required) [default: .user.yaml] Authorization
+                                 config yaml file (if not using the default
+                                 .user.yaml)
 
-  -e, --environment=environment  [default: .environment.yaml] environment config file
+  -e, --environment=environment  [default: .environment.yaml] environment config
+                                 file
 
-  --all                          Get all possible results from web API, possibly with multiple calls.
+  --all                          Get all possible results from web API, possibly
+                                 with multiple calls.
 
 EXAMPLE
   meeco organization-members:list <organization_id>
@@ -645,12 +692,18 @@ USAGE
   $ meeco organization-members:update
 
 OPTIONS
-  -a, --auth=auth                                          (required) [default: .user.yaml] Authorization config file
-                                                           yaml file (if not using the default .user.yaml)
+  -a, --auth=auth                                          (required) [default:
+                                                           .user.yaml]
+                                                           Authorization config
+                                                           yaml file (if not using
+                                                           the default .user.yaml)
 
-  -e, --environment=environment                            [default: .environment.yaml] environment config file
+  -e, --environment=environment                            [default:
+                                                           .environment.yaml]
+                                                           environment config file
 
-  -m, --organizationMemberConfig=organizationMemberConfig  (required) org member yaml file
+  -m, --organizationMemberConfig=organizationMemberConfig  (required) org member
+                                                           yaml file
 
 EXAMPLE
   meeco organization-members:update -m .my-created-org-member.yaml
@@ -667,15 +720,19 @@ USAGE
   $ meeco organization-services:create ORGANIZATION_ID
 
 OPTIONS
-  -a, --auth=auth                                            (required) [default: .user.yaml] Authorization config file
-                                                             yaml file (if not using the default .user.yaml)
+  -a, --auth=auth
+      (required) [default: .user.yaml] Authorization config yaml file (if not using
+      the default .user.yaml)
 
-  -c, --organizationServiceConfig=organizationServiceConfig  (required) organization service config file
+  -c, --organizationServiceConfig=organizationServiceConfig
+      (required) organization service config file
 
-  -e, --environment=environment                              [default: .environment.yaml] environment config file
+  -e, --environment=environment
+      [default: .environment.yaml] environment config file
 
 EXAMPLE
-  meeco organization-services:create <organization_id> -c .my-service-config.yaml > .my-created-service.yaml
+  meeco organization-services:create <organization_id> -c .my-service-config.yaml >
+  .my-created-service.yaml
 ```
 
 _See code: [src/commands/organization-services/create.ts](https://github.com/Meeco/cli/blob/master/src/commands/organization-services/create.ts)_
@@ -689,13 +746,16 @@ USAGE
   $ meeco organization-services:get ORGANIZATION_ID SERVICE_ID
 
 OPTIONS
-  -a, --auth=auth                (required) [default: .user.yaml] Authorization config file yaml file (if not using the
-                                 default .user.yaml)
+  -a, --auth=auth                (required) [default: .user.yaml] Authorization
+                                 config yaml file (if not using the default
+                                 .user.yaml)
 
-  -e, --environment=environment  [default: .environment.yaml] environment config file
+  -e, --environment=environment  [default: .environment.yaml] environment config
+                                 file
 
 EXAMPLE
-  meeco organization-services:get <organization_id> <service_id> > .my-created-service.yaml
+  meeco organization-services:get <organization_id> <service_id> >
+  .my-created-service.yaml
 ```
 
 _See code: [src/commands/organization-services/get.ts](https://github.com/Meeco/cli/blob/master/src/commands/organization-services/get.ts)_
@@ -709,12 +769,15 @@ USAGE
   $ meeco organization-services:list ORGANIZATION_ID
 
 OPTIONS
-  -a, --auth=auth                (required) [default: .user.yaml] Authorization config file yaml file (if not using the
-                                 default .user.yaml)
+  -a, --auth=auth                (required) [default: .user.yaml] Authorization
+                                 config yaml file (if not using the default
+                                 .user.yaml)
 
-  -e, --environment=environment  [default: .environment.yaml] environment config file
+  -e, --environment=environment  [default: .environment.yaml] environment config
+                                 file
 
-  --all                          Get all possible results from web API, possibly with multiple calls.
+  --all                          Get all possible results from web API, possibly
+                                 with multiple calls.
 
 EXAMPLE
   meeco organization-services:list <organization_id>
@@ -731,12 +794,15 @@ USAGE
   $ meeco organization-services:login
 
 OPTIONS
-  -a, --auth=auth                                            (required) [default: .user.yaml] Authorization config file
-                                                             yaml file (if not using the default .user.yaml)
+  -a, --auth=auth
+      (required) [default: .user.yaml] Authorization config yaml file (if not using
+      the default .user.yaml)
 
-  -e, --environment=environment                              [default: .environment.yaml] environment config file
+  -e, --environment=environment
+      [default: .environment.yaml] environment config file
 
-  -s, --organizationServiceConfig=organizationServiceConfig  (required) service yaml file
+  -s, --organizationServiceConfig=organizationServiceConfig
+      (required) service yaml file
 
 EXAMPLE
   meeco organization-services:login -s .my-created-service.yaml
@@ -753,12 +819,15 @@ USAGE
   $ meeco organization-services:update ORGANIZATION_ID
 
 OPTIONS
-  -a, --auth=auth                                            (required) [default: .user.yaml] Authorization config file
-                                                             yaml file (if not using the default .user.yaml)
+  -a, --auth=auth
+      (required) [default: .user.yaml] Authorization config yaml file (if not using
+      the default .user.yaml)
 
-  -e, --environment=environment                              [default: .environment.yaml] environment config file
+  -e, --environment=environment
+      [default: .environment.yaml] environment config file
 
-  -s, --organizationServiceConfig=organizationServiceConfig  (required) service yaml file
+  -s, --organizationServiceConfig=organizationServiceConfig
+      (required) service yaml file
 
 EXAMPLE
   meeco organization-services:update <organization_id> -s .my-created-service.yaml
@@ -775,15 +844,18 @@ USAGE
   $ meeco organizations:create
 
 OPTIONS
-  -a, --auth=auth                              (required) [default: .user.yaml] Authorization config file yaml file (if
+  -a, --auth=auth                              (required) [default: .user.yaml]
+                                               Authorization config yaml file (if
                                                not using the default .user.yaml)
 
   -c, --organizationConfig=organizationConfig  (required) organization config file
 
-  -e, --environment=environment                [default: .environment.yaml] environment config file
+  -e, --environment=environment                [default: .environment.yaml]
+                                               environment config file
 
 EXAMPLE
-  meeco organizations:create -c .my-organization-config.yaml > .my-created-organization.yaml
+  meeco organizations:create -c .my-organization-config.yaml >
+  .my-created-organization.yaml
 ```
 
 _See code: [src/commands/organizations/create.ts](https://github.com/Meeco/cli/blob/master/src/commands/organizations/create.ts)_
@@ -800,10 +872,12 @@ ARGUMENTS
   ID  ID of the Organization
 
 OPTIONS
-  -a, --auth=auth                (required) [default: .user.yaml] Authorization config file yaml file (if not using the
-                                 default .user.yaml)
+  -a, --auth=auth                (required) [default: .user.yaml] Authorization
+                                 config yaml file (if not using the default
+                                 .user.yaml)
 
-  -e, --environment=environment  [default: .environment.yaml] environment config file
+  -e, --environment=environment  [default: .environment.yaml] environment config
+                                 file
 
 EXAMPLE
   meeco organizations:delete <organization_id>
@@ -820,10 +894,12 @@ USAGE
   $ meeco organizations:get ID
 
 OPTIONS
-  -a, --auth=auth                (required) [default: .user.yaml] Authorization config file yaml file (if not using the
-                                 default .user.yaml)
+  -a, --auth=auth                (required) [default: .user.yaml] Authorization
+                                 config yaml file (if not using the default
+                                 .user.yaml)
 
-  -e, --environment=environment  [default: .environment.yaml] environment config file
+  -e, --environment=environment  [default: .environment.yaml] environment config
+                                 file
 
 EXAMPLE
   meeco organizations:get <organization_id>
@@ -840,18 +916,22 @@ USAGE
   $ meeco organizations:list
 
 OPTIONS
-  -a, --auth=auth                        (required) [default: .user.yaml] Authorization config file yaml file (if not
-                                         using the default .user.yaml)
+  -a, --auth=auth
+      (required) [default: .user.yaml] Authorization config yaml file (if not using
+      the default .user.yaml)
 
-  -e, --environment=environment          [default: .environment.yaml] environment config file
+  -e, --environment=environment
+      [default: .environment.yaml] environment config file
 
-  -m, --mode=validated|requested|member  [default: validated] There are three modes: validated, requested and member
-                                         validated - return all validated organizations
-                                         requested - list organizations in the requested state that the current user
-                                         has requested
-                                         member - list organizations in which the current user is a member.
+  -m, --mode=validated|requested|member
+      [default: validated] There are three modes: validated, requested and member
+        validated - return all validated organizations
+        requested - list organizations in the requested state that the current user
+      has requested
+        member - list organizations in which the current user is a member.
 
-  --all                                  Get all possible results from web API, possibly with multiple calls.
+  --all
+      Get all possible results from web API, possibly with multiple calls.
 
 EXAMPLE
   meeco organizations:list -m requested
@@ -868,10 +948,12 @@ USAGE
   $ meeco organizations:login
 
 OPTIONS
-  -a, --auth=auth                (required) [default: .user.yaml] Authorization config file yaml file (if not using the
-                                 default .user.yaml)
+  -a, --auth=auth                (required) [default: .user.yaml] Authorization
+                                 config yaml file (if not using the default
+                                 .user.yaml)
 
-  -e, --environment=environment  [default: .environment.yaml] environment config file
+  -e, --environment=environment  [default: .environment.yaml] environment config
+                                 file
 
   -o, --org=org                  (required) organization yaml file
 
@@ -890,10 +972,12 @@ USAGE
   $ meeco organizations:update
 
 OPTIONS
-  -a, --auth=auth                (required) [default: .user.yaml] Authorization config file yaml file (if not using the
-                                 default .user.yaml)
+  -a, --auth=auth                (required) [default: .user.yaml] Authorization
+                                 config yaml file (if not using the default
+                                 .user.yaml)
 
-  -e, --environment=environment  [default: .environment.yaml] environment config file
+  -e, --environment=environment  [default: .environment.yaml] environment config
+                                 file
 
   -o, --org=org                  (required) organization yaml file
 
@@ -915,10 +999,12 @@ ARGUMENTS
   SHAREID  ID of the share to accept
 
 OPTIONS
-  -a, --auth=auth                (required) [default: .user.yaml] Authorization config file yaml file (if not using the
-                                 default .user.yaml)
+  -a, --auth=auth                (required) [default: .user.yaml] Authorization
+                                 config yaml file (if not using the default
+                                 .user.yaml)
 
-  -e, --environment=environment  [default: .environment.yaml] environment config file
+  -e, --environment=environment  [default: .environment.yaml] environment config
+                                 file
 ```
 
 _See code: [src/commands/shares/accept.ts](https://github.com/Meeco/cli/blob/master/src/commands/shares/accept.ts)_
@@ -944,10 +1030,13 @@ OPTIONS
         anyone - anyone allow to on-share a share.
 
   -t, --acceptance_required=acceptance_not_required|acceptance_required
-      [default: acceptance_not_required] Some shares require that the recipient accepts the terms of the share.
-        There are two acceptance_require: acceptance_not_required & acceptance_required
+      [default: acceptance_not_required] Some shares require that the recipient
+      accepts the terms of the share.
+        There are two acceptance_require: acceptance_not_required &
+      acceptance_required
         acceptance_not_required - recipient dont require acceptance
-        acceptance_required - recipient require acceptance before viewing shared item.
+        acceptance_required - recipient require acceptance before viewing shared
+      item.
 ```
 
 _See code: [src/commands/shares/create.ts](https://github.com/Meeco/cli/blob/master/src/commands/shares/create.ts)_
@@ -962,10 +1051,18 @@ USAGE
 
 OPTIONS
   -c, --connectionId=connectionId  (required) Connection id for the 'to' user
-  -e, --environment=environment    [default: .environment.yaml] environment config file
+
+  -e, --environment=environment    [default: .environment.yaml] environment config
+                                   file
+
   -f, --from=from                  (required) User config file for the 'from' user
-  -i, --itemId=itemId              Item id of the 'from' user to share with the 'to' user
-  -o, --onshareId=onshareId        Share ID of the share, which to on-share with the 'to' user
+
+  -i, --itemId=itemId              Item id of the 'from' user to share with the
+                                   'to' user
+
+  -o, --onshareId=onshareId        Share ID of the share, which to on-share with
+                                   the 'to' user
+
   -s, --slotName=slotName          Name of slot to share (if sharing a single slot)
 ```
 
@@ -983,10 +1080,12 @@ ARGUMENTS
   SHAREID  ID of the shared item to fetch
 
 OPTIONS
-  -a, --auth=auth                (required) [default: .user.yaml] Authorization config file yaml file (if not using the
-                                 default .user.yaml)
+  -a, --auth=auth                (required) [default: .user.yaml] Authorization
+                                 config yaml file (if not using the default
+                                 .user.yaml)
 
-  -e, --environment=environment  [default: .environment.yaml] environment config file
+  -e, --environment=environment  [default: .environment.yaml] environment config
+                                 file
 ```
 
 _See code: [src/commands/shares/delete.ts](https://github.com/Meeco/cli/blob/master/src/commands/shares/delete.ts)_
@@ -1003,10 +1102,12 @@ ARGUMENTS
   SHAREID  ID of the share to fetch
 
 OPTIONS
-  -a, --auth=auth                (required) [default: .user.yaml] Authorization config file yaml file (if not using the
-                                 default .user.yaml)
+  -a, --auth=auth                (required) [default: .user.yaml] Authorization
+                                 config yaml file (if not using the default
+                                 .user.yaml)
 
-  -e, --environment=environment  [default: .environment.yaml] environment config file
+  -e, --environment=environment  [default: .environment.yaml] environment config
+                                 file
 ```
 
 _See code: [src/commands/shares/get-incoming.ts](https://github.com/Meeco/cli/blob/master/src/commands/shares/get-incoming.ts)_
@@ -1020,12 +1121,15 @@ USAGE
   $ meeco shares:list
 
 OPTIONS
-  -a, --auth=auth                (required) [default: .user.yaml] Authorization config file yaml file (if not using the
-                                 default .user.yaml)
+  -a, --auth=auth                (required) [default: .user.yaml] Authorization
+                                 config yaml file (if not using the default
+                                 .user.yaml)
 
-  -e, --environment=environment  [default: .environment.yaml] environment config file
+  -e, --environment=environment  [default: .environment.yaml] environment config
+                                 file
 
-  -t, --type=incoming|outgoing   [default: incoming] There are two type: incoming and Outgoing
+  -t, --type=incoming|outgoing   [default: incoming] There are two type: incoming
+                                 and Outgoing
                                  incoming - Read incoming shares as the recipien
                                  outgoing - Read outgoing shares as the sender.
 ```
@@ -1044,10 +1148,12 @@ ARGUMENTS
   ITEMID  ID of the share to fetch
 
 OPTIONS
-  -a, --auth=auth                (required) [default: .user.yaml] Authorization config file yaml file (if not using the
-                                 default .user.yaml)
+  -a, --auth=auth                (required) [default: .user.yaml] Authorization
+                                 config yaml file (if not using the default
+                                 .user.yaml)
 
-  -e, --environment=environment  [default: .environment.yaml] environment config file
+  -e, --environment=environment  [default: .environment.yaml] environment config
+                                 file
 ```
 
 _See code: [src/commands/shares/update.ts](https://github.com/Meeco/cli/blob/master/src/commands/shares/update.ts)_
@@ -1061,14 +1167,19 @@ USAGE
   $ meeco templates:info TEMPLATENAME
 
 OPTIONS
-  -a, --auth=auth                                  (required) [default: .user.yaml] Authorization config file yaml file
-                                                   (if not using the default .user.yaml)
+  -a, --auth=auth                                  (required) [default: .user.yaml]
+                                                   Authorization config yaml file
+                                                   (if not using the default
+                                                   .user.yaml)
 
-  -e, --environment=environment                    [default: .environment.yaml] environment config file
+  -e, --environment=environment                    [default: .environment.yaml]
+                                                   environment config file
 
-  -n, --classificationName=classificationName      Scope templates to a particular classification name
+  -n, --classificationName=classificationName      Scope templates to a particular
+                                                   classification name
 
-  -s, --classificationScheme=classificationScheme  Scope templates to a particular classification scheme
+  -s, --classificationScheme=classificationScheme  Scope templates to a particular
+                                                   classification scheme
 
 EXAMPLE
   meeco templates:info password
@@ -1085,18 +1196,25 @@ USAGE
   $ meeco templates:list
 
 OPTIONS
-  -a, --auth=auth                                  (required) [default: .user.yaml] Authorization config file yaml file
-                                                   (if not using the default .user.yaml)
+  -a, --auth=auth                                  (required) [default: .user.yaml]
+                                                   Authorization config yaml file
+                                                   (if not using the default
+                                                   .user.yaml)
 
-  -e, --environment=environment                    [default: .environment.yaml] environment config file
+  -e, --environment=environment                    [default: .environment.yaml]
+                                                   environment config file
 
   -l, --label=label                                Search label text
 
-  -n, --classificationName=classificationName      Scope templates to a particular classification name
+  -n, --classificationName=classificationName      Scope templates to a particular
+                                                   classification name
 
-  -s, --classificationScheme=classificationScheme  Scope templates to a particular classification scheme
+  -s, --classificationScheme=classificationScheme  Scope templates to a particular
+                                                   classification scheme
 
-  --all                                            Get all possible results from web API, possibly with multiple calls.
+  --all                                            Get all possible results from
+                                                   web API, possibly with multiple
+                                                   calls.
 ```
 
 _See code: [src/commands/templates/list.ts](https://github.com/Meeco/cli/blob/master/src/commands/templates/list.ts)_
@@ -1110,11 +1228,14 @@ USAGE
   $ meeco users:create
 
 OPTIONS
-  -e, --environment=environment  [default: .environment.yaml] environment config file
-  -p, --password=password        Password to use for the new user (will be prompted for if not provided)
+  -e, --environment=environment  [default: .environment.yaml] environment config
+                                 file
 
-  --port=port                    [default: 5210] Port to listen on for captcha response (optional - use if 5210 is
-                                 reserved)
+  -p, --password=password        Password to use for the new user (will be prompted
+                                 for if not provided)
+
+  --port=port                    [default: 5210] Port to listen on for captcha
+                                 response (optional - use if 5210 is reserved)
 
 EXAMPLE
   meeco users:create -p My$ecretPassword1
@@ -1131,10 +1252,20 @@ USAGE
   $ meeco users:get
 
 OPTIONS
-  -c, --user=user                User config file (if not providing secret and password)
-  -e, --environment=environment  [default: .environment.yaml] environment config file
-  -p, --password=password        the password of the user (will be prompted for if not provided)
-  -s, --secret=secret            the secret key of the user (will be prompted for if not provided)
+  -a, --auth=auth                [default: .user.yaml] Authorization config file
+                                 (if not using the default .user.yaml or password)
+
+  -c, --user=user                [Deprecated] User config file (if not providing
+                                 secret and password)
+
+  -e, --environment=environment  [default: .environment.yaml] environment config
+                                 file
+
+  -p, --password=password        the password of the user (will be prompted for if
+                                 not provided)
+
+  -s, --secret=secret            the secret key of the user (will be prompted for
+                                 if not provided)
 
 EXAMPLES
   meeco users:get -c path/to/user-config.yaml
@@ -1142,6 +1273,56 @@ EXAMPLES
 ```
 
 _See code: [src/commands/users/get.ts](https://github.com/Meeco/cli/blob/master/src/commands/users/get.ts)_
+
+## `meeco users:login`
+
+Refresh tokens for Keystore and Vault for the given user. Outputs an Authorization config file for use with future commands.
+
+```
+USAGE
+  $ meeco users:login
+
+OPTIONS
+  -a, --auth=auth                [default: .user.yaml] Authorization config file
+                                 (if not using the default .user.yaml or password)
+
+  -e, --environment=environment  [default: .environment.yaml] environment config
+                                 file
+
+  -p, --password=password        the password of the user (will be prompted for if
+                                 not provided)
+
+  -s, --secret=secret            the secret key of the user (will be prompted for
+                                 if not provided)
+
+EXAMPLES
+  meeco users:get -a path/to/stale-user-auth.yaml
+  meeco users:get -p My$ecretPassword1 -s 1.xxxxxx.xxxx-xxxxx-xxxxxxx-xxxxx
+```
+
+_See code: [src/commands/users/login.ts](https://github.com/Meeco/cli/blob/master/src/commands/users/login.ts)_
+
+## `meeco users:logout`
+
+Log the given user out of both keystore and vault.
+
+```
+USAGE
+  $ meeco users:logout
+
+OPTIONS
+  -a, --auth=auth                (required) [default: .user.yaml] Authorization
+                                 config yaml file (if not using the default
+                                 .user.yaml)
+
+  -e, --environment=environment  [default: .environment.yaml] environment config
+                                 file
+
+EXAMPLE
+  meeco users:logout -a path/to/user-auth.yaml
+```
+
+_See code: [src/commands/users/logout.ts](https://github.com/Meeco/cli/blob/master/src/commands/users/logout.ts)_
 
 <!-- commandsstop -->
 

--- a/packages/cli/src/commands/client-task-queue/list.ts
+++ b/packages/cli/src/commands/client-task-queue/list.ts
@@ -1,8 +1,8 @@
 import { ClientTaskQueueService, State } from '@meeco/sdk';
 import { flags as _flags } from '@oclif/command';
 import { AuthConfig } from '../../configs/auth-config';
-import { authFlags } from '../../flags/auth-flags';
-import { pageFlags } from '../../flags/page-flags';
+import authFlags from '../../flags/auth-flags';
+import pageFlags from '../../flags/page-flags';
 import MeecoCommand from '../../util/meeco-command';
 
 export default class ClientTaskQueueList extends MeecoCommand {

--- a/packages/cli/src/commands/connections/list.ts
+++ b/packages/cli/src/commands/connections/list.ts
@@ -1,7 +1,7 @@
 import { ConnectionService } from '@meeco/sdk';
 import { AuthConfig } from '../../configs/auth-config';
-import { authFlags } from '../../flags/auth-flags';
-import { pageFlags } from '../../flags/page-flags';
+import authFlags from '../../flags/auth-flags';
+import pageFlags from '../../flags/page-flags';
 import MeecoCommand from '../../util/meeco-command';
 
 export default class ConnectionsList extends MeecoCommand {

--- a/packages/cli/src/commands/items/create-config.ts
+++ b/packages/cli/src/commands/items/create-config.ts
@@ -3,7 +3,7 @@ import { flags as _flags } from '@oclif/command';
 import { CLIError } from '@oclif/errors';
 import { AuthConfig } from '../../configs/auth-config';
 import { ItemConfig } from '../../configs/item-config';
-import { authFlags } from '../../flags/auth-flags';
+import authFlags from '../../flags/auth-flags';
 import MeecoCommand from '../../util/meeco-command';
 
 export default class ItemsCreateConfig extends MeecoCommand {

--- a/packages/cli/src/commands/items/create.ts
+++ b/packages/cli/src/commands/items/create.ts
@@ -2,7 +2,7 @@ import { ItemCreateData, ItemService } from '@meeco/sdk';
 import { flags as _flags } from '@oclif/command';
 import { AuthConfig } from '../../configs/auth-config';
 import { ItemConfig } from '../../configs/item-config';
-import { authFlags } from '../../flags/auth-flags';
+import authFlags from '../../flags/auth-flags';
 import MeecoCommand from '../../util/meeco-command';
 
 export default class ItemsCreate extends MeecoCommand {

--- a/packages/cli/src/commands/items/get-thumbnail.ts
+++ b/packages/cli/src/commands/items/get-thumbnail.ts
@@ -3,7 +3,7 @@ import { ItemService } from '@meeco/sdk';
 import { flags as _flags } from '@oclif/command';
 import { CLIError } from '@oclif/errors';
 import { AuthConfig } from '../../configs/auth-config';
-import { authFlags } from '../../flags/auth-flags';
+import authFlags from '../../flags/auth-flags';
 import { writeFileContents } from '../../util/file';
 import MeecoCommand from '../../util/meeco-command';
 

--- a/packages/cli/src/commands/items/get.ts
+++ b/packages/cli/src/commands/items/get.ts
@@ -1,7 +1,7 @@
 import { ItemService } from '@meeco/sdk';
 import { AuthConfig } from '../../configs/auth-config';
 import { ItemConfig } from '../../configs/item-config';
-import { authFlags } from '../../flags/auth-flags';
+import authFlags from '../../flags/auth-flags';
 import MeecoCommand from '../../util/meeco-command';
 import ItemsList from './list';
 

--- a/packages/cli/src/commands/items/list.ts
+++ b/packages/cli/src/commands/items/list.ts
@@ -1,8 +1,8 @@
 import { ItemService } from '@meeco/sdk';
 import { AuthConfig } from '../../configs/auth-config';
 import { ItemListConfig } from '../../configs/item-list-config';
-import { authFlags } from '../../flags/auth-flags';
-import { pageFlags } from '../../flags/page-flags';
+import authFlags from '../../flags/auth-flags';
+import pageFlags from '../../flags/page-flags';
 import MeecoCommand from '../../util/meeco-command';
 
 export default class ItemsList extends MeecoCommand {

--- a/packages/cli/src/commands/items/remove-slot.ts
+++ b/packages/cli/src/commands/items/remove-slot.ts
@@ -1,6 +1,6 @@
 import { ItemService } from '@meeco/sdk';
 import { AuthConfig } from '../../configs/auth-config';
-import { authFlags } from '../../flags/auth-flags';
+import authFlags from '../../flags/auth-flags';
 import MeecoCommand from '../../util/meeco-command';
 
 export default class ItemsRemoveSlot extends MeecoCommand {

--- a/packages/cli/src/commands/items/update.ts
+++ b/packages/cli/src/commands/items/update.ts
@@ -2,7 +2,7 @@ import { ClientTaskQueueService, ItemService, ItemUpdateData } from '@meeco/sdk'
 import { flags as _flags } from '@oclif/command';
 import { AuthConfig } from '../../configs/auth-config';
 import { ItemConfig } from '../../configs/item-config';
-import { authFlags } from '../../flags/auth-flags';
+import authFlags from '../../flags/auth-flags';
 import MeecoCommand from '../../util/meeco-command';
 
 export default class ItemsUpdate extends MeecoCommand {

--- a/packages/cli/src/commands/organization-members/accept-invitation.ts
+++ b/packages/cli/src/commands/organization-members/accept-invitation.ts
@@ -3,7 +3,7 @@ import { flags as _flags } from '@oclif/command';
 import { AuthConfig } from '../../configs/auth-config';
 import { ConnectionV2Config } from '../../configs/connection-v2-config';
 import { InvitationConfig } from '../../configs/invitation-config';
-import { authFlags } from '../../flags/auth-flags';
+import authFlags from '../../flags/auth-flags';
 import MeecoCommand from '../../util/meeco-command';
 
 export default class OrganizationMembersAcceptInvitation extends MeecoCommand {

--- a/packages/cli/src/commands/organization-members/create-invitation.ts
+++ b/packages/cli/src/commands/organization-members/create-invitation.ts
@@ -3,7 +3,7 @@ import { flags as _flags } from '@oclif/command';
 import { AuthConfig } from '../../configs/auth-config';
 import { InvitationConfig } from '../../configs/invitation-config';
 import { OrganizationConfig } from '../../configs/organization-config';
-import { authFlags } from '../../flags/auth-flags';
+import authFlags from '../../flags/auth-flags';
 import MeecoCommand from '../../util/meeco-command';
 
 export default class OrganizationMembersCreateInvitation extends MeecoCommand {

--- a/packages/cli/src/commands/organization-members/delete.ts
+++ b/packages/cli/src/commands/organization-members/delete.ts
@@ -1,6 +1,6 @@
 import { vaultAPIFactory } from '@meeco/sdk';
 import { AuthConfig } from '../../configs/auth-config';
-import { authFlags } from '../../flags/auth-flags';
+import authFlags from '../../flags/auth-flags';
 import MeecoCommand from '../../util/meeco-command';
 
 export default class OrganizationMembersDelete extends MeecoCommand {

--- a/packages/cli/src/commands/organization-members/list.ts
+++ b/packages/cli/src/commands/organization-members/list.ts
@@ -1,7 +1,7 @@
 import { getAllPaged, reducePagesTakeLast, reportIfTruncated, vaultAPIFactory } from '@meeco/sdk';
 import { AuthConfig } from '../../configs/auth-config';
-import { authFlags } from '../../flags/auth-flags';
-import { pageFlags } from '../../flags/page-flags';
+import authFlags from '../../flags/auth-flags';
+import pageFlags from '../../flags/page-flags';
 import MeecoCommand from '../../util/meeco-command';
 
 export default class OrganizationMembersList extends MeecoCommand {

--- a/packages/cli/src/commands/organization-members/update.ts
+++ b/packages/cli/src/commands/organization-members/update.ts
@@ -2,7 +2,7 @@ import { vaultAPIFactory } from '@meeco/sdk';
 import { flags as _flags } from '@oclif/command';
 import { AuthConfig } from '../../configs/auth-config';
 import { OrganizationMemberConfig } from '../../configs/organization-member-config';
-import { authFlags } from '../../flags/auth-flags';
+import authFlags from '../../flags/auth-flags';
 import MeecoCommand from '../../util/meeco-command';
 
 export default class OrganizationMembersUpdate extends MeecoCommand {

--- a/packages/cli/src/commands/organization-services/create.ts
+++ b/packages/cli/src/commands/organization-services/create.ts
@@ -2,7 +2,7 @@ import { OrganizationServicesService } from '@meeco/sdk';
 import { flags as _flags } from '@oclif/command';
 import { AuthConfig } from '../../configs/auth-config';
 import { OrganizationServiceConfig } from '../../configs/organization-service-config';
-import { authFlags } from '../../flags/auth-flags';
+import authFlags from '../../flags/auth-flags';
 import MeecoCommand from '../../util/meeco-command';
 
 export default class OrganizationServicesCreate extends MeecoCommand {

--- a/packages/cli/src/commands/organization-services/get.ts
+++ b/packages/cli/src/commands/organization-services/get.ts
@@ -1,7 +1,7 @@
 import { vaultAPIFactory } from '@meeco/sdk';
 import { AuthConfig } from '../../configs/auth-config';
 import { OrganizationServiceConfig } from '../../configs/organization-service-config';
-import { authFlags } from '../../flags/auth-flags';
+import authFlags from '../../flags/auth-flags';
 import MeecoCommand from '../../util/meeco-command';
 
 export default class OrganizationServicesGet extends MeecoCommand {

--- a/packages/cli/src/commands/organization-services/list.ts
+++ b/packages/cli/src/commands/organization-services/list.ts
@@ -1,8 +1,8 @@
 import { getAllPaged, reducePages, reportIfTruncated, vaultAPIFactory } from '@meeco/sdk';
 import { AuthConfig } from '../../configs/auth-config';
 import { OrganizationServiceListConfig } from '../../configs/organization-services-list-config';
-import { authFlags } from '../../flags/auth-flags';
-import { pageFlags } from '../../flags/page-flags';
+import authFlags from '../../flags/auth-flags';
+import pageFlags from '../../flags/page-flags';
 import MeecoCommand from '../../util/meeco-command';
 
 export default class OrganizationServicesList extends MeecoCommand {

--- a/packages/cli/src/commands/organization-services/login.ts
+++ b/packages/cli/src/commands/organization-services/login.ts
@@ -2,7 +2,7 @@ import { OrganizationServicesService } from '@meeco/sdk';
 import { flags as _flags } from '@oclif/command';
 import { AuthConfig } from '../../configs/auth-config';
 import { OrganizationServiceConfig } from '../../configs/organization-service-config';
-import { authFlags } from '../../flags/auth-flags';
+import authFlags from '../../flags/auth-flags';
 import MeecoCommand from '../../util/meeco-command';
 
 export default class OrganizationServicesLogin extends MeecoCommand {

--- a/packages/cli/src/commands/organization-services/update.ts
+++ b/packages/cli/src/commands/organization-services/update.ts
@@ -2,7 +2,7 @@ import { vaultAPIFactory } from '@meeco/sdk';
 import { flags as _flags } from '@oclif/command';
 import { AuthConfig } from '../../configs/auth-config';
 import { OrganizationServiceConfig } from '../../configs/organization-service-config';
-import { authFlags } from '../../flags/auth-flags';
+import authFlags from '../../flags/auth-flags';
 import MeecoCommand from '../../util/meeco-command';
 
 export default class OrganizationServicesUpdate extends MeecoCommand {

--- a/packages/cli/src/commands/organizations/create.ts
+++ b/packages/cli/src/commands/organizations/create.ts
@@ -2,7 +2,7 @@ import { OrganizationsService } from '@meeco/sdk';
 import { flags as _flags } from '@oclif/command';
 import { AuthConfig } from '../../configs/auth-config';
 import { OrganizationConfig } from '../../configs/organization-config';
-import { authFlags } from '../../flags/auth-flags';
+import authFlags from '../../flags/auth-flags';
 import MeecoCommand from '../../util/meeco-command';
 
 export default class CreateOrganisation extends MeecoCommand {

--- a/packages/cli/src/commands/organizations/delete.ts
+++ b/packages/cli/src/commands/organizations/delete.ts
@@ -1,6 +1,6 @@
 import { vaultAPIFactory } from '@meeco/sdk';
 import { AuthConfig } from '../../configs/auth-config';
-import { authFlags } from '../../flags/auth-flags';
+import authFlags from '../../flags/auth-flags';
 import MeecoCommand from '../../util/meeco-command';
 
 export default class OrganizationsDelete extends MeecoCommand {

--- a/packages/cli/src/commands/organizations/get.ts
+++ b/packages/cli/src/commands/organizations/get.ts
@@ -1,7 +1,7 @@
 import { vaultAPIFactory } from '@meeco/sdk';
 import { AuthConfig } from '../../configs/auth-config';
 import { OrganizationConfig } from '../../configs/organization-config';
-import { authFlags } from '../../flags/auth-flags';
+import authFlags from '../../flags/auth-flags';
 import MeecoCommand from '../../util/meeco-command';
 
 export default class OrganizationsGet extends MeecoCommand {

--- a/packages/cli/src/commands/organizations/list.ts
+++ b/packages/cli/src/commands/organizations/list.ts
@@ -2,8 +2,8 @@ import { getAllPaged, reducePages, reportIfTruncated, vaultAPIFactory } from '@m
 import { flags as _flags } from '@oclif/command';
 import { AuthConfig } from '../../configs/auth-config';
 import { OrganizationsListConfig } from '../../configs/organizations-list-config';
-import { authFlags } from '../../flags/auth-flags';
-import { pageFlags } from '../../flags/page-flags';
+import authFlags from '../../flags/auth-flags';
+import pageFlags from '../../flags/page-flags';
 import MeecoCommand from '../../util/meeco-command';
 
 export default class OrganizationsList extends MeecoCommand {

--- a/packages/cli/src/commands/organizations/login.ts
+++ b/packages/cli/src/commands/organizations/login.ts
@@ -2,7 +2,7 @@ import { OrganizationsService } from '@meeco/sdk';
 import { flags as _flags } from '@oclif/command';
 import { AuthConfig } from '../../configs/auth-config';
 import { OrganizationConfig } from '../../configs/organization-config';
-import { authFlags } from '../../flags/auth-flags';
+import authFlags from '../../flags/auth-flags';
 import MeecoCommand from '../../util/meeco-command';
 
 export default class OrganizationsLogin extends MeecoCommand {

--- a/packages/cli/src/commands/organizations/update.ts
+++ b/packages/cli/src/commands/organizations/update.ts
@@ -2,7 +2,7 @@ import { vaultAPIFactory } from '@meeco/sdk';
 import { flags as _flags } from '@oclif/command';
 import { AuthConfig } from '../../configs/auth-config';
 import { OrganizationConfig } from '../../configs/organization-config';
-import { authFlags } from '../../flags/auth-flags';
+import authFlags from '../../flags/auth-flags';
 import MeecoCommand from '../../util/meeco-command';
 
 export default class OrganizationsUpdate extends MeecoCommand {

--- a/packages/cli/src/commands/templates/info.ts
+++ b/packages/cli/src/commands/templates/info.ts
@@ -5,7 +5,7 @@ import { CLIError } from '@oclif/errors';
 import { cli } from 'cli-ux';
 import { AuthConfig } from '../../configs/auth-config';
 import { TemplateConfig } from '../../configs/template-config';
-import { authFlags } from '../../flags/auth-flags';
+import authFlags from '../../flags/auth-flags';
 import MeecoCommand from '../../util/meeco-command';
 
 export default class TemplatesInfo extends MeecoCommand {

--- a/packages/cli/src/commands/templates/list.ts
+++ b/packages/cli/src/commands/templates/list.ts
@@ -3,8 +3,8 @@ import { flags as _flags } from '@oclif/command';
 import { cli } from 'cli-ux';
 import { AuthConfig } from '../../configs/auth-config';
 import { TemplateConfig } from '../../configs/template-config';
-import { authFlags } from '../../flags/auth-flags';
-import { pageFlags } from '../../flags/page-flags';
+import authFlags from '../../flags/auth-flags';
+import pageFlags from '../../flags/page-flags';
 import MeecoCommand from '../../util/meeco-command';
 
 export default class TemplatesList extends MeecoCommand {

--- a/packages/cli/src/commands/users/get.ts
+++ b/packages/cli/src/commands/users/get.ts
@@ -1,6 +1,6 @@
 import { UserService } from '@meeco/sdk';
 import { AuthConfig } from '../../configs/auth-config';
-import { userFlags } from '../../flags/user-flags';
+import userFlags from '../../flags/user-flags';
 import MeecoCommand from '../../util/meeco-command';
 
 export default class GetUser extends MeecoCommand {

--- a/packages/cli/src/commands/users/get.ts
+++ b/packages/cli/src/commands/users/get.ts
@@ -3,6 +3,7 @@ import { MeResponse } from '@meeco/vault-api-sdk';
 import { flags as _flags } from '@oclif/command';
 import cli from 'cli-ux';
 import { AuthConfig } from '../../configs/auth-config';
+import { UserDataConfig } from '../../configs/user-data-config';
 import userFlags from '../../flags/user-flags';
 import MeecoCommand from '../../util/meeco-command';
 
@@ -57,7 +58,6 @@ export default class GetUser extends MeecoCommand {
         // TODO this duplicates work, would be nice to implement in SDK
         const authResult = await service.get(password, secret);
         result = await service.getVaultUser(authResult.vault_access_token);
-
       } else {
         const authConfig = await this.readConfigFromFile(AuthConfig, auth);
         if (!authConfig) {
@@ -67,7 +67,7 @@ export default class GetUser extends MeecoCommand {
         result = await api.UserApi.meGet();
       }
 
-      this.printYaml(result);
+      this.printYaml(UserDataConfig.encodeFromJSON(result));
     } catch (err) {
       await this.handleException(err);
     }

--- a/packages/cli/src/commands/users/get.ts
+++ b/packages/cli/src/commands/users/get.ts
@@ -1,4 +1,4 @@
-import { UserService, vaultAPIFactory } from '@meeco/sdk';
+import { UserService } from '@meeco/sdk';
 import { MeResponse } from '@meeco/vault-api-sdk';
 import { flags as _flags } from '@oclif/command';
 import cli from 'cli-ux';
@@ -55,16 +55,13 @@ export default class GetUser extends MeecoCommand {
           }
         }
 
-        // TODO this duplicates work, would be nice to implement in SDK
-        const authResult = await service.get(password, secret);
-        result = await service.getVaultUser(authResult.vault_access_token);
+        result = await service.getVaultToken(password, secret).then(service.getVaultUser);
       } else {
         const authConfig = await this.readConfigFromFile(AuthConfig, auth);
         if (!authConfig) {
           this.error('Must specify a valid auth config file');
         }
-        const api = vaultAPIFactory(environment)(authConfig);
-        result = await api.UserApi.meGet();
+        result = await service.getVaultUser(authConfig.vault_access_token);
       }
 
       this.printYaml(UserDataConfig.encodeFromJSON(result));

--- a/packages/cli/src/commands/users/get.ts
+++ b/packages/cli/src/commands/users/get.ts
@@ -55,13 +55,15 @@ export default class GetUser extends MeecoCommand {
           }
         }
 
-        result = await service.getVaultToken(password, secret).then(service.getVaultUser);
+        result = await service
+          .getOrCreateVaultToken(password, secret)
+          .then(token => service.getUser(token));
       } else {
         const authConfig = await this.readConfigFromFile(AuthConfig, auth);
         if (!authConfig) {
           this.error('Must specify a valid auth config file');
         }
-        result = await service.getVaultUser(authConfig.vault_access_token);
+        result = await service.getUser(authConfig.vault_access_token);
       }
 
       this.printYaml(UserDataConfig.encodeFromJSON(result));

--- a/packages/cli/src/commands/users/get.ts
+++ b/packages/cli/src/commands/users/get.ts
@@ -1,4 +1,5 @@
 import { UserService } from '@meeco/sdk';
+import { flags } from '@oclif/command';
 import { AuthConfig } from '../../configs/auth-config';
 import userFlags from '../../flags/user-flags';
 import MeecoCommand from '../../util/meeco-command';
@@ -13,6 +14,12 @@ export default class GetUser extends MeecoCommand {
 
   static flags = {
     ...MeecoCommand.flags,
+    user: flags.string({
+      char: 'c',
+      description: '[Deprecated] User config file (if not providing secret and password)',
+      required: false,
+      exclusive: ['password', 'secret'],
+    }),
     ...userFlags,
   };
 

--- a/packages/cli/src/commands/users/get.ts
+++ b/packages/cli/src/commands/users/get.ts
@@ -1,5 +1,7 @@
-import { UserService } from '@meeco/sdk';
-import { flags } from '@oclif/command';
+import { UserService, vaultAPIFactory } from '@meeco/sdk';
+import { MeResponse } from '@meeco/vault-api-sdk';
+import { flags as _flags } from '@oclif/command';
+import cli from 'cli-ux';
 import { AuthConfig } from '../../configs/auth-config';
 import userFlags from '../../flags/user-flags';
 import MeecoCommand from '../../util/meeco-command';
@@ -14,23 +16,58 @@ export default class GetUser extends MeecoCommand {
 
   static flags = {
     ...MeecoCommand.flags,
-    user: flags.string({
+    user: _flags.string({
       char: 'c',
       description: '[Deprecated] User config file (if not providing secret and password)',
       required: false,
       exclusive: ['password', 'secret'],
     }),
     ...userFlags,
+    auth: _flags.string({
+      char: 'a',
+      required: false,
+      description: 'Authorization config file (if not using the default .user.yaml or password)',
+      default: '.user.yaml',
+    }),
   };
 
   async run() {
-    const { secret, password } = await this.readUserConfig();
+    const { flags } = this.parse(this.constructor as typeof GetUser);
 
-    const environment = await this.readEnvironmentFile();
-    const service = new UserService(environment, this.updateStatus);
     try {
-      const result = await service.get(password, secret);
-      this.printYaml(AuthConfig.encodeFromAuthData(result));
+      const environment = await this.readEnvironmentFile();
+      const service = new UserService(environment, this.updateStatus);
+
+      const { user, auth } = flags;
+
+      // get secret and pass either from file or flags
+      const parseResult = user ? await this.readUserConfig() : flags;
+      const { secret } = parseResult;
+      let { password } = parseResult;
+
+      let result: MeResponse;
+
+      if (secret) {
+        if (!password) {
+          while (!password) {
+            password = await cli.prompt('Enter your password', { type: 'hide' });
+          }
+        }
+
+        // TODO this duplicates work, would be nice to implement in SDK
+        const authResult = await service.get(password, secret);
+        result = await service.getVaultUser(authResult.vault_access_token);
+
+      } else {
+        const authConfig = await this.readConfigFromFile(AuthConfig, auth);
+        if (!authConfig) {
+          this.error('Must specify a valid auth config file');
+        }
+        const api = vaultAPIFactory(environment)(authConfig);
+        result = await api.UserApi.meGet();
+      }
+
+      this.printYaml(result);
     } catch (err) {
       await this.handleException(err);
     }

--- a/packages/cli/src/commands/users/login.ts
+++ b/packages/cli/src/commands/users/login.ts
@@ -9,7 +9,6 @@ export default class LoginUser extends MeecoCommand {
   static description =
     'Refresh tokens for Keystore and Vault for the given user. Outputs an Authorization config file for use with future commands.';
   static examples = [
-    `meeco users:get -c path/to/user-config.yaml`,
     `meeco users:get -a path/to/stale-user-auth.yaml`,
     `meeco users:get -p My$ecretPassword1 -s 1.xxxxxx.xxxx-xxxxx-xxxxxxx-xxxxx`,
   ];

--- a/packages/cli/src/commands/users/login.ts
+++ b/packages/cli/src/commands/users/login.ts
@@ -1,0 +1,57 @@
+import { UserService } from '@meeco/sdk';
+import { flags as _flags } from '@oclif/command';
+import cli from 'cli-ux';
+import { AuthConfig } from '../../configs/auth-config';
+import userFlags from '../../flags/user-flags';
+import MeecoCommand from '../../util/meeco-command';
+
+export default class LoginUser extends MeecoCommand {
+  static description =
+    'Refresh tokens for Keystore and Vault for the given user. Outputs an Authorization config file for use with future commands.';
+  static examples = [
+    `meeco users:get -c path/to/user-config.yaml`,
+    `meeco users:get -a path/to/stale-user-auth.yaml`,
+    `meeco users:get -p My$ecretPassword1 -s 1.xxxxxx.xxxx-xxxxx-xxxxxxx-xxxxx`,
+  ];
+
+  static flags = {
+    ...MeecoCommand.flags,
+    ...userFlags,
+    auth: _flags.string({
+      char: 'a',
+      required: false,
+      description: 'Authorization config file (if not using the default .user.yaml or password)',
+      default: '.user.yaml',
+    }),
+  };
+
+  async run() {
+    const { flags } = this.parse(this.constructor as typeof LoginUser);
+    const { auth } = flags;
+    let { secret, password } = flags;
+
+    try {
+      const environment = await this.readEnvironmentFile();
+      const service = new UserService(environment, this.updateStatus);
+
+      if (!password) {
+        while (!password) {
+          password = await cli.prompt('Enter your password', { type: 'hide' });
+        }
+      }
+
+      if (!secret) {
+        const authConfig = await this.readConfigFromFile(AuthConfig, auth);
+        if (!authConfig) {
+          this.error('Must specify a valid auth config file');
+        }
+        secret = authConfig.secret;
+      }
+
+      const result = await service.get(password, secret);
+      this.printYaml(AuthConfig.encodeFromAuthData(result));
+    } catch (err) {
+      await this.handleException(err);
+    }
+  }
+}

--- a/packages/cli/src/commands/users/logout.ts
+++ b/packages/cli/src/commands/users/logout.ts
@@ -5,10 +5,7 @@ import MeecoCommand from '../../util/meeco-command';
 
 export default class LogoutUser extends MeecoCommand {
   static description = 'Log the given user out of both keystore and vault.';
-  static examples = [
-    `meeco users:logout -a path/to/user-auth.yaml`,
-    `meeco users:logout -p My$ecretPassword1 -s 1.xxxxxx.xxxx-xxxxx-xxxxxxx-xxxxx`,
-  ];
+  static examples = [`meeco users:logout -a path/to/user-auth.yaml`];
 
   static flags = {
     ...MeecoCommand.flags,
@@ -20,13 +17,16 @@ export default class LogoutUser extends MeecoCommand {
 
     try {
       const environment = await this.readEnvironmentFile();
-      const service = new UserService(environment, this.updateStatus);
+      const service = new UserService(environment);
       const { auth } = flags;
       const authConfig = await this.readConfigFromFile(AuthConfig, auth);
       if (!authConfig) {
         this.error('Must specify a valid auth config file');
       }
-      service.deleteSessions(authConfig.vault_access_token, authConfig.keystore_access_token);
+
+      this.updateStatus('Logging out');
+      await service.deleteSessions(authConfig.vault_access_token, authConfig.keystore_access_token);
+      this.finish();
     } catch (err) {
       await this.handleException(err);
     }

--- a/packages/cli/src/commands/users/logout.ts
+++ b/packages/cli/src/commands/users/logout.ts
@@ -25,7 +25,10 @@ export default class LogoutUser extends MeecoCommand {
       }
 
       this.updateStatus('Logging out');
-      await service.deleteSessions(authConfig.vault_access_token, authConfig.keystore_access_token);
+      await service.deleteSessionTokens(
+        authConfig.vault_access_token,
+        authConfig.keystore_access_token
+      );
       this.finish();
     } catch (err) {
       await this.handleException(err);

--- a/packages/cli/src/commands/users/logout.ts
+++ b/packages/cli/src/commands/users/logout.ts
@@ -1,0 +1,34 @@
+import { UserService } from '@meeco/sdk';
+import { AuthConfig } from '../../configs/auth-config';
+import authFlags from '../../flags/auth-flags';
+import MeecoCommand from '../../util/meeco-command';
+
+export default class LogoutUser extends MeecoCommand {
+  static description = 'Log the given user out of both keystore and vault.';
+  static examples = [
+    `meeco users:logout -a path/to/user-auth.yaml`,
+    `meeco users:logout -p My$ecretPassword1 -s 1.xxxxxx.xxxx-xxxxx-xxxxxxx-xxxxx`,
+  ];
+
+  static flags = {
+    ...MeecoCommand.flags,
+    ...authFlags,
+  };
+
+  async run() {
+    const { flags } = this.parse(this.constructor as typeof LogoutUser);
+
+    try {
+      const environment = await this.readEnvironmentFile();
+      const service = new UserService(environment, this.updateStatus);
+      const { auth } = flags;
+      const authConfig = await this.readConfigFromFile(AuthConfig, auth);
+      if (!authConfig) {
+        this.error('Must specify a valid auth config file');
+      }
+      service.deleteSessions(authConfig.vault_access_token, authConfig.keystore_access_token);
+    } catch (err) {
+      await this.handleException(err);
+    }
+  }
+}

--- a/packages/cli/src/configs/user-data-config.ts
+++ b/packages/cli/src/configs/user-data-config.ts
@@ -1,0 +1,40 @@
+import { MeResponse, PutMeRequestUser } from '@meeco/vault-api-sdk';
+import { CLIError } from '@oclif/errors';
+import { ConfigReader, IYamlConfig } from './yaml-config';
+
+export interface IUserDataTemplate extends PutMeRequestUser {
+  id?: string;
+}
+
+@ConfigReader<UserDataConfig>()
+export class UserDataConfig {
+  static kind = 'UserData';
+
+  constructor(public readonly userConfig: IUserDataTemplate) {}
+
+  static fromYamlConfig(yamlConfigObj: IYamlConfig<IUserDataTemplate>): UserDataConfig {
+    if (yamlConfigObj.kind !== UserDataConfig.kind) {
+      throw new CLIError(
+        `Config file of incorrect kind: '${yamlConfigObj.kind}' (expected '${UserDataConfig.kind}')`
+      );
+    }
+
+    return new UserDataConfig(yamlConfigObj.spec);
+  }
+
+  static encodeFromJSON(json: MeResponse) {
+    const data = Object.entries(json.user).reduce((acc, [k, v]) => {
+      if (v !== null) {
+        acc[k] = v;
+      }
+      return acc;
+    }, {});
+
+    return {
+      kind: UserDataConfig.kind,
+      spec: {
+        ...data,
+      },
+    };
+  }
+}

--- a/packages/cli/src/flags/auth-flags.ts
+++ b/packages/cli/src/flags/auth-flags.ts
@@ -8,3 +8,5 @@ export const authFlags = {
     default: '.user.yaml',
   }),
 };
+
+export default authFlags;

--- a/packages/cli/src/flags/auth-flags.ts
+++ b/packages/cli/src/flags/auth-flags.ts
@@ -4,7 +4,7 @@ export const authFlags = {
   auth: flags.string({
     char: 'a',
     required: true,
-    description: 'Authorization config file yaml file (if not using the default .user.yaml)',
+    description: 'Authorization config yaml file (if not using the default .user.yaml)',
     default: '.user.yaml',
   }),
 };

--- a/packages/cli/src/flags/page-flags.ts
+++ b/packages/cli/src/flags/page-flags.ts
@@ -6,3 +6,5 @@ export const pageFlags = {
     default: false,
   }),
 };
+
+export default pageFlags;

--- a/packages/cli/src/flags/user-flags.ts
+++ b/packages/cli/src/flags/user-flags.ts
@@ -20,3 +20,5 @@ export const userFlags = {
     exclusive: ['user'],
   }),
 };
+
+export default userFlags;

--- a/packages/cli/src/flags/user-flags.ts
+++ b/packages/cli/src/flags/user-flags.ts
@@ -1,12 +1,6 @@
 import { flags } from '@oclif/command';
 
 export const userFlags = {
-  user: flags.string({
-    char: 'c',
-    description: 'User config file (if not providing secret and password)',
-    required: false,
-    exclusive: ['password', 'secret'],
-  }),
   password: flags.string({
     char: 'p',
     description: 'the password of the user (will be prompted for if not provided)',

--- a/packages/cli/test/commands/users/create.test.ts
+++ b/packages/cli/test/commands/users/create.test.ts
@@ -1,20 +1,9 @@
 import { SecretService, UserService } from '@meeco/sdk';
 import { expect } from '@oclif/test';
-import open from 'cli-ux/lib/open';
 import { readFileSync } from 'fs';
-import * as request from 'node-fetch';
 import { customTest, outputFixture, testEnvironmentFile } from '../../test-helpers';
 
-describe('meeco users:create', () => {
-  (<any>open) = () => {
-    return request('http://localhost:5210/', {
-      method: 'post',
-      body: JSON.stringify({
-        'g-recaptcha-response': 'mock_captcha',
-      }),
-      headers: { 'Content-Type': 'application/json' },
-    });
-  };
+describe('users:create', () => {
   customTest
     .stub(UserService.prototype, 'create', create as any)
     .stderr()

--- a/packages/cli/test/commands/users/get.test.ts
+++ b/packages/cli/test/commands/users/get.test.ts
@@ -1,11 +1,17 @@
 import { UserService } from '@meeco/sdk';
 import { expect } from '@oclif/test';
 import { readFileSync } from 'fs';
-import { customTest, inputFixture, outputFixture, testEnvironmentFile } from '../../test-helpers';
+import {
+  customTest,
+  inputFixture,
+  outputFixture,
+  testEnvironmentFile,
+  testUserAuth,
+} from '../../test-helpers';
 
 describe('users:get', () => {
   customTest
-    .stub(UserService.prototype, 'get', get as any)
+    .stub(UserService.prototype, 'getVaultToken', getVaultToken as any)
     .stub(UserService.prototype, 'getVaultUser', getVaultUser as any)
     .stderr()
     .stdout()
@@ -19,7 +25,7 @@ describe('users:get', () => {
     );
 
   customTest
-    .stub(UserService.prototype, 'get', get as any)
+    .stub(UserService.prototype, 'getVaultToken', getVaultToken as any)
     .stub(UserService.prototype, 'getVaultUser', getVaultUser as any)
     .stderr()
     .stdout()
@@ -35,20 +41,22 @@ describe('users:get', () => {
       const expected = readFileSync(outputFixture('get-user.output.yaml'), 'utf-8');
       expect(ctx.stdout.trim()).to.contain(expected.trim());
     });
+
+  customTest
+    .stub(UserService.prototype, 'getVaultUser', getVaultUser as any)
+    .stderr()
+    .stdout()
+    .run(['users:get', ...testUserAuth, ...testEnvironmentFile])
+    .it('retrieves all user details with an auth config file', ctx => {
+      const expected = readFileSync(outputFixture('get-user.output.yaml'), 'utf-8');
+      expect(ctx.stdout.trim()).to.contain(expected.trim());
+    });
 });
 
-function get(password, secret) {
-  return Promise.resolve({
-    data_encryption_key:
-      'ZGF0YV9lbmNyeXB0aW9uX2tleVtkZWNyeXB0ZWQgd2l0aCBrZXlfZW5jcnlwdGlvbl9rZXlbZGVjcnlwdGVkIHdpdGggZGVyaXZlZF9rZXlfMTIzLmFzdXBlcnNlY3JldHBhc3NwaHJhc2VdXQ==',
-    key_encryption_key:
-      'a2V5X2VuY3J5cHRpb25fa2V5W2RlY3J5cHRlZCB3aXRoIGRlcml2ZWRfa2V5XzEyMy5hc3VwZXJzZWNyZXRwYXNzcGhyYXNlXQ==',
-    keystore_access_token: 'keystore_auth_token',
-    passphrase_derived_key: 'ZGVyaXZlZF9rZXlfMTIzLmFzdXBlcnNlY3JldHBhc3NwaHJhc2U=',
-    secret,
-    vault_access_token:
-      '[decrypted]vault_auth_token--PRIVATE_KEY--12324[decrypted with key_encryption_key[decrypted with derived_key_123.asupersecretpassphrase]]',
-  });
+function getVaultToken(password, secret) {
+  return Promise.resolve(
+    '[decrypted]vault_auth_token--PRIVATE_KEY--12324[decrypted with key_encryption_key[decrypted with derived_key_123.asupersecretpassphrase]]'
+  );
 }
 
 function getVaultUser(token) {
@@ -67,28 +75,3 @@ function getVaultUser(token) {
     associations: [],
   });
 }
-
-// function vaultAPIFactory(environment) {
-//   return authConfig => ({
-//     OrganizationsForVaultUsersApi: {
-//       organizationsIdGet: id => {
-//         return Promise.resolve({
-//           organization: {
-//             id: '00000000-0000-0000-0000-000000000000',
-//             name: 'SuperData Inc.',
-//             description: 'My super data handling organization',
-//             url: 'https://superdata.example.com',
-//             email: 'admin@superdata.example.com',
-//             status: 'requested',
-//             requestor_id: '00000000-0000-0000-0000-000000000000',
-//             validated_by_id: null,
-//             agent_id: null,
-//             validated_at: null,
-//             created_at: new Date('2020-06-23T08:38:32.915Z'),
-//           },
-//           services: [],
-//         });
-//       },
-//     },
-//   });
-// }

--- a/packages/cli/test/commands/users/get.test.ts
+++ b/packages/cli/test/commands/users/get.test.ts
@@ -11,8 +11,8 @@ import {
 
 describe('users:get', () => {
   customTest
-    .stub(UserService.prototype, 'getVaultToken', getVaultToken as any)
-    .stub(UserService.prototype, 'getVaultUser', getVaultUser as any)
+    .stub(UserService.prototype, 'getOrCreateVaultToken', getVaultToken as any)
+    .stub(UserService.prototype, 'getUser', getUser as any)
     .stderr()
     .stdout()
     .run(['users:get', '-c', inputFixture('get-user.input.yaml'), ...testEnvironmentFile])
@@ -25,8 +25,8 @@ describe('users:get', () => {
     );
 
   customTest
-    .stub(UserService.prototype, 'getVaultToken', getVaultToken as any)
-    .stub(UserService.prototype, 'getVaultUser', getVaultUser as any)
+    .stub(UserService.prototype, 'getOrCreateVaultToken', getVaultToken as any)
+    .stub(UserService.prototype, 'getUser', getUser as any)
     .stderr()
     .stdout()
     .run([
@@ -43,7 +43,7 @@ describe('users:get', () => {
     });
 
   customTest
-    .stub(UserService.prototype, 'getVaultUser', getVaultUser as any)
+    .stub(UserService.prototype, 'getUser', getUser as any)
     .stderr()
     .stdout()
     .run(['users:get', ...testUserAuth, ...testEnvironmentFile])
@@ -59,7 +59,7 @@ function getVaultToken(password, secret) {
   );
 }
 
-function getVaultUser(token) {
+function getUser(token) {
   return Promise.resolve({
     user: {
       id: '68a2cdb3-4a9d-42ac-83e7-d7e4967143a0',

--- a/packages/cli/test/commands/users/get.test.ts
+++ b/packages/cli/test/commands/users/get.test.ts
@@ -3,19 +3,24 @@ import { expect } from '@oclif/test';
 import { readFileSync } from 'fs';
 import { customTest, inputFixture, outputFixture, testEnvironmentFile } from '../../test-helpers';
 
-describe('meeco users:get', () => {
+describe('users:get', () => {
   customTest
     .stub(UserService.prototype, 'get', get as any)
+    .stub(UserService.prototype, 'getVaultUser', getVaultUser as any)
     .stderr()
     .stdout()
     .run(['users:get', '-c', inputFixture('get-user.input.yaml'), ...testEnvironmentFile])
-    .it('retrieves all user details with credentials provided in a yaml config file', ctx => {
-      const expected = readFileSync(outputFixture('get-user.output.yaml'), 'utf-8');
-      expect(ctx.stdout.trim()).to.contain(expected.trim());
-    });
+    .it(
+      'retrieves all user details with credentials provided in a yaml config file [Deprecated]',
+      ctx => {
+        const expected = readFileSync(outputFixture('get-user.output.yaml'), 'utf-8');
+        expect(ctx.stdout.trim()).to.contain(expected.trim());
+      }
+    );
 
   customTest
     .stub(UserService.prototype, 'get', get as any)
+    .stub(UserService.prototype, 'getVaultUser', getVaultUser as any)
     .stderr()
     .stdout()
     .run([
@@ -40,8 +45,50 @@ function get(password, secret) {
       'a2V5X2VuY3J5cHRpb25fa2V5W2RlY3J5cHRlZCB3aXRoIGRlcml2ZWRfa2V5XzEyMy5hc3VwZXJzZWNyZXRwYXNzcGhyYXNlXQ==',
     keystore_access_token: 'keystore_auth_token',
     passphrase_derived_key: 'ZGVyaXZlZF9rZXlfMTIzLmFzdXBlcnNlY3JldHBhc3NwaHJhc2U=',
-    secret: '1.user-1.my_secret_key',
+    secret,
     vault_access_token:
       '[decrypted]vault_auth_token--PRIVATE_KEY--12324[decrypted with key_encryption_key[decrypted with derived_key_123.asupersecretpassphrase]]',
   });
 }
+
+function getVaultUser(token) {
+  return Promise.resolve({
+    user: {
+      id: '68a2cdb3-4a9d-42ac-83e7-d7e4967143a0',
+      email: '',
+      is_app_logging_enabled: false,
+      track_events: true,
+      track_usage: true,
+      private_dek_external_id: '5c5d0d86-119d-4e2f-87c7-6503f60a97d5',
+      accepted_terms: false,
+      association_ids: [],
+      user_type: null,
+    },
+    associations: [],
+  });
+}
+
+// function vaultAPIFactory(environment) {
+//   return authConfig => ({
+//     OrganizationsForVaultUsersApi: {
+//       organizationsIdGet: id => {
+//         return Promise.resolve({
+//           organization: {
+//             id: '00000000-0000-0000-0000-000000000000',
+//             name: 'SuperData Inc.',
+//             description: 'My super data handling organization',
+//             url: 'https://superdata.example.com',
+//             email: 'admin@superdata.example.com',
+//             status: 'requested',
+//             requestor_id: '00000000-0000-0000-0000-000000000000',
+//             validated_by_id: null,
+//             agent_id: null,
+//             validated_at: null,
+//             created_at: new Date('2020-06-23T08:38:32.915Z'),
+//           },
+//           services: [],
+//         });
+//       },
+//     },
+//   });
+// }

--- a/packages/cli/test/commands/users/login.test.ts
+++ b/packages/cli/test/commands/users/login.test.ts
@@ -1,0 +1,50 @@
+import { UserService } from '@meeco/sdk';
+import { expect } from '@oclif/test';
+import { readFileSync } from 'fs';
+import { customTest, outputFixture, testEnvironmentFile, testUserAuth } from '../../test-helpers';
+
+describe('users:login', () => {
+  customTest
+    .stub(UserService.prototype, 'get', get as any)
+    .stderr()
+    .stdout()
+    .run([
+      'users:login',
+      '-s',
+      '1.mocked_generated_username.my_secret_key',
+      '-p',
+      '123.asupersecretpassphrase',
+      ...testEnvironmentFile,
+    ])
+    .it('generates a token when given a secret and password', ctx => {
+      const expected = readFileSync(outputFixture('create-user.output.yaml'), 'utf-8');
+      expect(ctx.stdout.trim()).to.contain(expected.trim());
+    });
+
+  customTest
+    .stub(UserService.prototype, 'get', get as any)
+    .stderr()
+    .stdout()
+    .run([
+      'users:login',
+      ...testUserAuth,
+      '-p',
+      '123.asupersecretpassphrase',
+      ...testEnvironmentFile,
+    ])
+    .it('generates a token when given an auth config)', ctx => {
+      const expected = readFileSync(outputFixture('create-user.output.yaml'), 'utf-8');
+      expect(ctx.stdout.trim()).to.contain(expected.trim());
+    });
+});
+
+function get(password, secret) {
+  return Promise.resolve({
+    data_encryption_key: 'cmFuZG9tbHlfZ2VuZXJhdGVkX2tleQ==',
+    key_encryption_key: 'cmFuZG9tbHlfZ2VuZXJhdGVkX2tleQ==',
+    keystore_access_token: 'keystore_auth_token',
+    passphrase_derived_key: 'ZGVyaXZlZF9rZXlfMTIzLmFzdXBlcnNlY3JldHBhc3NwaHJhc2U=',
+    secret,
+    vault_access_token: '[decrypted]encrypted_vault_session_string--PRIVATE_KEY--12324',
+  });
+}

--- a/packages/cli/test/commands/users/logout.test.ts
+++ b/packages/cli/test/commands/users/logout.test.ts
@@ -4,7 +4,7 @@ import { customTest, testEnvironmentFile, testUserAuth } from '../../test-helper
 
 describe('users:logout', () => {
   customTest
-    .stub(UserService.prototype, 'deleteSessions', deleteTokens as any)
+    .stub(UserService.prototype, 'deleteSessionTokens', deleteTokens as any)
     .stderr()
     .stdout()
     .run(['users:logout', ...testUserAuth, ...testEnvironmentFile])

--- a/packages/cli/test/commands/users/logout.test.ts
+++ b/packages/cli/test/commands/users/logout.test.ts
@@ -1,0 +1,19 @@
+import { UserService } from '@meeco/sdk';
+import { expect } from '@oclif/test';
+import { customTest, testEnvironmentFile, testUserAuth } from '../../test-helpers';
+
+describe('users:logout', () => {
+  customTest
+    .stub(UserService.prototype, 'deleteSessions', deleteTokens as any)
+    .stderr()
+    .stdout()
+    .run(['users:logout', ...testUserAuth, ...testEnvironmentFile])
+    .it('deletes tokens when given an auth config)', ctx => {
+      const expected = 'Logging out... done';
+      expect(ctx.stderr.trim()).to.contain(expected.trim());
+    });
+});
+
+function deleteTokens(vaultToken, keystoreToken) {
+  return Promise.resolve([]);
+}

--- a/packages/cli/test/fixtures/inputs/user-auth.input.yaml
+++ b/packages/cli/test/fixtures/inputs/user-auth.input.yaml
@@ -5,3 +5,5 @@ metadata:
   data_encryption_key: bXlfZ2VuZXJhdGVkX2Rlaw==
   key_encryption_key: bXlfa2V5X2VuY3J5cHRpb25fa2V5
   passphrase_derived_key: BsKhFEfDtTfDscK6PMOrwr3DiToiwrFbJ2V4OMO7wqFmw55Q
+  secret: 1.mocked_generated_username.my_secret_key
+spec: {}

--- a/packages/cli/test/fixtures/outputs/get-user.output.yaml
+++ b/packages/cli/test/fixtures/outputs/get-user.output.yaml
@@ -1,9 +1,10 @@
-kind: Authentication
-metadata:
-  data_encryption_key: ZGF0YV9lbmNyeXB0aW9uX2tleVtkZWNyeXB0ZWQgd2l0aCBrZXlfZW5jcnlwdGlvbl9rZXlbZGVjcnlwdGVkIHdpdGggZGVyaXZlZF9rZXlfMTIzLmFzdXBlcnNlY3JldHBhc3NwaHJhc2VdXQ==
-  key_encryption_key: a2V5X2VuY3J5cHRpb25fa2V5W2RlY3J5cHRlZCB3aXRoIGRlcml2ZWRfa2V5XzEyMy5hc3VwZXJzZWNyZXRwYXNzcGhyYXNlXQ==
-  keystore_access_token: keystore_auth_token
-  passphrase_derived_key: ZGVyaXZlZF9rZXlfMTIzLmFzdXBlcnNlY3JldHBhc3NwaHJhc2U=
-  secret: 1.user-1.my_secret_key
-  vault_access_token: "[decrypted]vault_auth_token--PRIVATE_KEY--12324[decrypted with
-    key_encryption_key[decrypted with derived_key_123.asupersecretpassphrase]]"
+kind: UserData
+spec:
+  id: 68a2cdb3-4a9d-42ac-83e7-d7e4967143a0
+  email: ""
+  is_app_logging_enabled: false
+  track_events: true
+  track_usage: true
+  private_dek_external_id: 5c5d0d86-119d-4e2f-87c7-6503f60a97d5
+  accepted_terms: false
+  association_ids: []

--- a/packages/sdk/README.md
+++ b/packages/sdk/README.md
@@ -165,7 +165,7 @@ In future, if we want to retrieve the user's `AuthData` we need them to provide 
 import { UserService } from '@meeco/sdk';
 
 const userService = new UserService(environment);
-const user = await userService.get(password, secret);
+const user = await userService.getAuthData(password, secret);
 // We have logged the user back in again and have the encryption keys we need
 ```
 

--- a/packages/sdk/src/services/user-service.ts
+++ b/packages/sdk/src/services/user-service.ts
@@ -360,4 +360,11 @@ export class UserService {
   public getVaultUser(vaultAccessToken: string) {
     return this.vaultApiFactory(vaultAccessToken).UserApi.meGet();
   }
+
+  public deleteSessions(vaultToken: string, keystoreToken: string) {
+    return Promise.all([
+      this.vaultApiFactory(vaultToken).SessionApi.sessionDelete(),
+      this.keystoreApiFactory(keystoreToken).SessionApi.sessionDelete()
+    ]);
+  }
 }

--- a/packages/sdk/src/services/user-service.ts
+++ b/packages/sdk/src/services/user-service.ts
@@ -357,6 +357,16 @@ export class UserService {
     });
   }
 
+  public async getKeystoreToken(userPassword: string, secret: string) {
+    return this.loginKeystoreViaSRP(userPassword, secret);
+  }
+
+  public async getVaultToken(userPassword: string, secret: string) {
+    return this.loginKeystoreViaSRP(userPassword, secret)
+      .then(token => this.requestExternalAdmissionTokens(token))
+      .then(({ vault_api_admission_token }) => vault_api_admission_token);
+  }
+
   public getVaultUser(vaultAccessToken: string) {
     return this.vaultApiFactory(vaultAccessToken).UserApi.meGet();
   }
@@ -364,7 +374,7 @@ export class UserService {
   public deleteSessions(vaultToken: string, keystoreToken: string) {
     return Promise.all([
       this.vaultApiFactory(vaultToken).SessionApi.sessionDelete(),
-      this.keystoreApiFactory(keystoreToken).SessionApi.sessionDelete()
+      this.keystoreApiFactory(keystoreToken).SessionApi.sessionDelete(),
     ]);
   }
 }


### PR DESCRIPTION
I needed some user manipulation commands to write integration test scripts (like the e2e.sh).

# CLI
Adds the following commands:
* `users:login -a [authConfig] -s [secret] -p [password]`-- recreates/gets tokens and prints auth-config.
* `users:logout -a [authConfig]`-- invalidates the tokens in the auth-config file.

Redefines
* `users:get` now prints user info instead of auth-config.

# SDK UserService
Methods to support the above commands, and some renamings to avoid confusion (get -> gets user data or auth-config?).
Originals of renamed methods are marked as deprecated, so no breaking changes in SDK.

Adds
* `createKeystoreToken`
* `deleteSessionTokens`
* `getOrCreateVaultToken`, essentially `get` but only returns a token
* `getUser` renamed `getVaultUser`.
* `getAuthData` renamed `get`

The following methods are marked as deprecated: `get`, `getVaultUser`.