### PR TITLE
Feature/sdk share enums

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1002,25 +1002,15 @@ USAGE
   $ meeco shares:create [FILE]
 
 OPTIONS
-  -c, --config=config
-      (required) Share config file to use for setting up the share
+  -c, --config=config                                                      (required) Share config file to use for setting up the share
+  -d, --expiry_date=expiry_date                                            Share expiry date either ISO-8601 or yyyy-MM-dd short format e.g. 2020-12-31
+  -e, --environment=environment                                            [default: .environment.yaml] environment config file
 
-  -d, --expiry_date=expiry_date
-      Share expiry date either ISO-8601 or yyyy-MM-dd short format e.g. 2020-12-31
+  -m, --sharing_mode=(owner|anyone)                                        [default: owner] If set to anyone, allows a share recipient to share this Item
+                                                                           again.
 
-  -e, --environment=environment
-      [default: .environment.yaml] environment config file
-
-  -m, --sharing_mode=owner|anyone
-      [default: owner] There are two sharing_mode: owner and anyone
-        owner - non-owner will not be able to on-share a share
-        anyone - anyone allow to on-share a share.
-
-  -t, --acceptance_required=acceptance_not_required|acceptance_required
-      [default: acceptance_not_required] Some shares require that the recipient accepts the terms of the share.
-        There are two acceptance_require: acceptance_not_required & acceptance_required
-        acceptance_not_required - recipient dont require acceptance
-        acceptance_required - recipient require acceptance before viewing shared item.
+  -t, --acceptance_required=(acceptance_required|acceptance_not_required)  [default: acceptance_not_required] If set to 'acceptance_required' then recipient
+                                                                           must accept share terms before decrypting the shared item.
 ```
 
 _See code: [src/commands/shares/create.ts](https://github.com/Meeco/cli/blob/master/src/commands/shares/create.ts)_
@@ -1093,14 +1083,12 @@ USAGE
   $ meeco shares:list
 
 OPTIONS
-  -a, --auth=auth                (required) [default: .user.yaml] Authorization config yaml file (if not using the
-                                 default .user.yaml)
+  -a, --auth=auth                 (required) [default: .user.yaml] Authorization config yaml file (if not using the default .user.yaml)
+  -e, --environment=environment   [default: .environment.yaml] environment config file
 
-  -e, --environment=environment  [default: .environment.yaml] environment config file
-
-  -t, --type=incoming|outgoing   [default: incoming] There are two types: incoming and outgoing
-                                 incoming - Items shared with you
-                                 outgoing - Items you have shared
+  -t, --type=(incoming|outgoing)  [default: incoming] There are two types: incoming and outgoing
+                                  incoming - Items shared with you
+                                  outgoing - Items you have shared
 ```
 
 _See code: [src/commands/shares/list.ts](https://github.com/Meeco/cli/blob/master/src/commands/shares/list.ts)_

--- a/packages/cli/src/commands/shares/create.ts
+++ b/packages/cli/src/commands/shares/create.ts
@@ -1,8 +1,9 @@
-import { ShareService } from '@meeco/sdk';
+import { AcceptanceStatus, ShareService, SharingMode } from '@meeco/sdk';
 import { flags as _flags } from '@oclif/command';
 import { isAfter, isValid, parse, parseISO } from 'date-fns';
 import { ShareConfig } from '../../configs/share-config';
 import MeecoCommand from '../../util/meeco-command';
+
 export default class SharesCreate extends MeecoCommand {
   static description = 'Share an item between two users';
 
@@ -13,21 +14,19 @@ export default class SharesCreate extends MeecoCommand {
       description: 'Share config file to use for setting up the share',
       required: true,
     }),
-    sharing_mode: _flags.string({
+    sharing_mode: _flags.enum({
       char: 'm',
-      default: 'owner',
+      default: SharingMode.owner,
       required: false,
-      options: ['owner', 'anyone'],
-      description:
-        'There are two sharing_mode: owner and anyone \n owner - non-owner will not be able to on-share a share \n anyone - anyone allow to on-share a share.',
+      options: Object.values(SharingMode),
+      description: 'If set to anyone, allows a share recipient to share this Item again.',
     }),
-    acceptance_required: _flags.string({
+    acceptance_required: _flags.enum({
       char: 't',
-      default: 'acceptance_not_required',
+      default: AcceptanceStatus.notRequired,
       required: false,
-      options: ['acceptance_not_required', 'acceptance_required'],
-      description:
-        'Some shares require that the recipient accepts the terms of the share. \n There are two acceptance_require: acceptance_not_required & acceptance_required \n acceptance_not_required - recipient dont require acceptance  \n acceptance_required - recipient require acceptance before viewing shared item.',
+      options: Object.values(AcceptanceStatus),
+      description: `If set to 'acceptance_required' then recipient must accept share terms before decrypting the shared item.`,
     }),
     expiry_date: _flags.string({
       char: 'd',
@@ -65,6 +64,7 @@ export default class SharesCreate extends MeecoCommand {
       }
 
       const service = new ShareService(environment, this.updateStatus);
+
       const result = await service.shareItem(share.from, share.connectionId, share.itemId, {
         expires_at: expiry_date ? parseDate : undefined,
         sharing_mode,

--- a/packages/cli/src/commands/shares/list.ts
+++ b/packages/cli/src/commands/shares/list.ts
@@ -11,11 +11,11 @@ export default class SharesList extends MeecoCommand {
   static flags = {
     ...MeecoCommand.flags,
     ...authFlags,
-    type: _flags.string({
+    type: _flags.enum({
       char: 't',
-      default: 'incoming',
+      default: ShareType.incoming,
       required: false,
-      options: ['incoming', 'outgoing'],
+      options: Object.values(ShareType),
       description:
         'There are two types: incoming and outgoing \n incoming - Items shared with you \n outgoing - Items you have shared',
     }),
@@ -35,8 +35,7 @@ export default class SharesList extends MeecoCommand {
     const service = new ShareService(environment, this.updateStatus);
 
     try {
-      const shareType = ShareType[type];
-      const shares = await service.listShares(authConfig, shareType);
+      const shares = await service.listShares(authConfig, type);
       this.printYaml(ShareListConfig.encodeFromJson(shares));
     } catch (err) {
       await this.handleException(err);

--- a/packages/cli/test/commands/shares/create.test.ts
+++ b/packages/cli/test/commands/shares/create.test.ts
@@ -9,17 +9,14 @@ describe('shares:create', () => {
   const constantDate = new Date(1);
   const value_verification_hash =
     '925c874c3345fd71f24fafb7231432749cd8761b93e455da68187e666c25d341';
+
   customTest
     .stdout()
     .stderr()
     .mockCryppo()
-    .stub(
-      ShareService,
-      'generate_value_verification_hash',
-      sinon.stub().returns(value_verification_hash)
-    )
+    .stub(ShareService, 'valueVerificationHash', sinon.stub().returns(value_verification_hash))
     .stub(ShareService, 'Date', sinon.stub().returns(constantDate))
-    .nock('https://sandbox.meeco.me/vault', stubVault(false))
+    .nock('https://sandbox.meeco.me/vault', stubVault(value_verification_hash, false))
     .run([
       'shares:create',
       '-c',
@@ -34,23 +31,14 @@ describe('shares:create', () => {
       const expected = readFileSync(outputFixture('create-share.output.yaml'), 'utf-8');
       expect(ctx.stdout.trim()).to.contain(expected.trim());
     });
-});
 
-describe('shares:create one slot', () => {
-  const constantDate = new Date(1);
-  const value_verification_hash =
-    '925c874c3345fd71f24fafb7231432749cd8761b93e455da68187e666c25d341';
   customTest
     .stdout()
     .stderr()
     .mockCryppo()
-    .stub(
-      ShareService,
-      'generate_value_verification_hash',
-      sinon.stub().returns(value_verification_hash)
-    )
+    .stub(ShareService, 'valueVerificationHash', sinon.stub().returns(value_verification_hash))
     .stub(ShareService, 'Date', sinon.stub().returns(constantDate))
-    .nock('https://sandbox.meeco.me/vault', stubVault(true))
+    .nock('https://sandbox.meeco.me/vault', stubVault(value_verification_hash, true))
     .run([
       'shares:create',
       '-c',
@@ -65,11 +53,8 @@ describe('shares:create one slot', () => {
     });
 });
 
-function stubVault(shareSingleSlot: boolean) {
+function stubVault(value_verification_hash: string, shareSingleSlot: boolean) {
   return (api: nock.Scope) => {
-    const value_verification_hash =
-      '925c874c3345fd71f24fafb7231432749cd8761b93e455da68187e666c25d341';
-
     api
       .get('/items/from_user_vault_item_to_share_id')
       .matchHeader('Authorization', 'from_user_vault_access_token')

--- a/packages/cli/test/commands/shares/get-incoming.test.ts
+++ b/packages/cli/test/commands/shares/get-incoming.test.ts
@@ -1,4 +1,4 @@
-import { ShareService } from '@meeco/sdk';
+import { ItemService } from '@meeco/sdk';
 import { expect } from '@oclif/test';
 import { readFileSync } from 'fs';
 import * as nock from 'nock';
@@ -6,18 +6,11 @@ import sinon from 'sinon';
 import { customTest, outputFixture, testEnvironmentFile, testUserAuth } from '../../test-helpers';
 
 describe('shares:get-incoming', () => {
-  const value_verification_hash =
-    '91ab18573ee6dd109f89d819244ce98e654c3c0682ca1f54bb550efc4d6b3c2c';
-
   customTest
     .stdout()
     .stderr()
     .mockCryppo()
-    .stub(
-      ShareService,
-      'generate_value_verification_hash',
-      sinon.stub().returns(value_verification_hash)
-    )
+    .stub(ItemService, 'verifyHashedValue', sinon.stub().returns(true))
     .nock('https://sandbox.meeco.me/vault', mockVault)
     .nock('https://sandbox.meeco.me/keystore', mockKeystore)
     .run([

--- a/packages/sdk/src/index.ts
+++ b/packages/sdk/src/index.ts
@@ -25,5 +25,6 @@ export * from './services/user-service';
 export * from './util/api-factory';
 export * from './util/find-connection-between';
 export * from './util/paged';
+export * from './util/value-verification';
 import _cryppo from './services/cryppo-service';
 export const _cryppoService = _cryppo;

--- a/packages/sdk/src/services/item-service.ts
+++ b/packages/sdk/src/services/item-service.ts
@@ -42,6 +42,8 @@ export interface IDecryptedSlot extends Slot {
  */
 export class ItemService {
   private static cryppo = (<any>global).cryppo || cryppo;
+  private static verifyHashedValue = (<any>global).verifyHashedValue || verifyHashedValue;
+
   private vaultAPIFactory: VaultAPIFactory;
   private keystoreAPIFactory: KeystoreAPIFactory;
   private logger: IFullLogger;
@@ -82,7 +84,7 @@ export class ItemService {
 
           if (
             slot.value_verification_hash !== null &&
-            !verifyHashedValue(
+            !ItemService.verifyHashedValue(
               decryptedValueVerificationKey as string,
               value,
               slot.value_verification_hash

--- a/packages/sdk/src/services/item-service.ts
+++ b/packages/sdk/src/services/item-service.ts
@@ -3,6 +3,7 @@ import {
   AttachmentDirectUploadUrlResponse,
   AttachmentResponse,
   CreateAttachmentResponse,
+  Item,
   ItemsResponse,
   PostAttachmentDirectUploadUrlRequest,
   Slot,
@@ -21,10 +22,15 @@ import { ItemUpdateData } from '../models/item-update-data';
 import { DecryptedSlot } from '../models/local-slot';
 import { MeecoServiceError } from '../models/service-error';
 import cryppo from '../services/cryppo-service';
-import { VaultAPIFactory, vaultAPIFactory } from '../util/api-factory';
+import {
+  KeystoreAPIFactory,
+  keystoreAPIFactory,
+  VaultAPIFactory,
+  vaultAPIFactory,
+} from '../util/api-factory';
 import { IFullLogger, Logger, noopLogger, SimpleLogger, toFullLogger } from '../util/logger';
 import { getAllPaged, reducePages, resultHasNext } from '../util/paged';
-import { ShareService } from './share-service';
+import { valueVerificationHash } from '../util/value-verification';
 
 export interface IDecryptedSlot extends Slot {
   value_verification_key?: string;
@@ -37,13 +43,15 @@ export interface IDecryptedSlot extends Slot {
 export class ItemService {
   private static cryppo = (<any>global).cryppo || cryppo;
   private vaultAPIFactory: VaultAPIFactory;
-  private shareService: ShareService;
+  private keystoreAPIFactory: KeystoreAPIFactory;
   private logger: IFullLogger;
+  // for mocking during testing
+  private cryppo = (<any>global).cryppo || cryppo;
 
   constructor(environment: Environment, log: SimpleLogger = noopLogger) {
     this.vaultAPIFactory = vaultAPIFactory(environment);
+    this.keystoreAPIFactory = keystoreAPIFactory(environment);
 
-    this.shareService = new ShareService(environment, log);
     this.logger = toFullLogger(log);
   }
 
@@ -73,10 +81,8 @@ export class ItemService {
           });
 
           value =
-            ShareService.generate_value_verification_hash(
-              decryptedValueVerificationKey as string,
-              value
-            ) === slot.value_verification_hash
+            valueVerificationHash(decryptedValueVerificationKey as string, value) ===
+            slot.value_verification_hash
               ? value
               : 'Invalid Value: failed to verify integrity of slot value';
         }
@@ -90,6 +96,16 @@ export class ItemService {
         return decrypted;
       })
     );
+  }
+
+  /**
+   * True if the Item was received via a Share from another user.
+   * In that case, it must be decrypted with the Share DEK, not the user's own DEK.
+   * @param item
+   */
+  public static itemIsFromShare(item: Item): boolean {
+    // this also implies item.own == false
+    return item.share_id != null;
   }
 
   public setLogger(logger: Logger) {
@@ -332,20 +348,39 @@ export class ItemService {
 
   public async get(id: string, user: AuthData) {
     const vaultAccessToken = user.vault_access_token;
-    const dataEncryptionKey = user.data_encryption_key;
+    let dataEncryptionKey = user.data_encryption_key;
 
     const result = await this.vaultAPIFactory(vaultAccessToken).ItemApi.itemsIdGet(id);
+    const { item, slots } = result;
 
-    // this could be improved, consider finding a way of using only one item get call.
-    if (result.item.share_id != null) {
-      return this.shareService.getSharedItemIncoming(user, result.item.share_id);
+    // If the Item is from a share, use the share DEK to decrypt instead.
+    if (ItemService.itemIsFromShare(item) && item.share_id !== null) {
+      const share = await this.vaultAPIFactory(user)
+        .SharesApi.incomingSharesIdGet(item.share_id)
+        .then(response => response.share);
+
+      const keyPairExternal = await this.keystoreAPIFactory(user).KeypairApi.keypairsIdGet(
+        share.keypair_external_id!
+      );
+
+      const decryptedPrivateKey = await this.cryppo.decryptWithKey({
+        serialized: keyPairExternal.keypair.encrypted_serialized_key,
+        key: user.key_encryption_key.key,
+      });
+
+      dataEncryptionKey = await this.cryppo
+        .decryptSerializedWithPrivateKey({
+          privateKeyPem: decryptedPrivateKey,
+          serialized: share.encrypted_dek,
+        })
+        .then(EncryptionKey.fromRaw);
     }
 
-    const slots = await ItemService.decryptAllSlots(result.slots, dataEncryptionKey);
+    const decryptedSlots = await ItemService.decryptAllSlots(slots, dataEncryptionKey);
 
     return {
       ...result,
-      slots,
+      slots: decryptedSlots,
     };
   }
 

--- a/packages/sdk/src/services/share-service.ts
+++ b/packages/sdk/src/services/share-service.ts
@@ -65,7 +65,11 @@ export class ShareService {
   static Date = global.Date;
 
   // for mocking during testing
+  private static valueVerificationHash =
+    (<any>global).valueVerificationHash || valueVerificationHash;
+
   private cryppo = (<any>global).cryppo || cryppo;
+
   private keystoreApiFactory: KeystoreAPIFactory;
   private vaultApiFactory: VaultAPIFactory;
 
@@ -398,7 +402,7 @@ export class ShareService {
 
         // this will be replace by cryppo call later
         const verificationHash = slot.own
-          ? valueVerificationHash(valueVerificationKey as string, slot.value as string)
+          ? ShareService.valueVerificationHash(valueVerificationKey as string, slot.value as string)
           : undefined;
 
         return {

--- a/packages/sdk/src/util/value-verification.ts
+++ b/packages/sdk/src/util/value-verification.ts
@@ -9,6 +9,6 @@ export function valueVerificationHash(verificationKey: string, value: string) {
   return hmacSha256Digest(verificationKey, value);
 }
 
-export function checkHashedValue(verificationKey: string, value: string, hash: string): boolean {
+export function verifyHashedValue(verificationKey: string, value: string, hash: string): boolean {
   return valueVerificationHash(verificationKey, value) === hash;
 }

--- a/packages/sdk/src/util/value-verification.ts
+++ b/packages/sdk/src/util/value-verification.ts
@@ -1,0 +1,14 @@
+import { hmacSha256Digest } from '@meeco/cryppo/dist/src/digests/hmac-digest';
+
+/**
+ * Verify integrity of shared Slot Values using message authentication hashing.
+ * @param verificationKey Recommended to be 64 bytes long.
+ * @param value Plaintext to hash.
+ */
+export function valueVerificationHash(verificationKey: string, value: string) {
+  return hmacSha256Digest(verificationKey, value);
+}
+
+export function checkHashedValue(verificationKey: string, value: string, hash: string): boolean {
+  return valueVerificationHash(verificationKey, value) === hash;
+}


### PR DESCRIPTION
SDK changes:
* Export enums from sdk/ShareService for use in creating a Share. These are for `share.sharing_mode` and `share.acceptance_required`.
* `ShareService.generate_value_verification_hash` is moved to `util.valueVerificationHash`.

~~CLI changes:~~
* ~~Use enums in CLI, changing flags for `shares:create` from `shares:create -m anyone -t acceptance_required` to `shares:create --onshare --accept`.~~

**I pushed the CLI changes out to #114, so this only requires a minor-version bump on SDK**