### PR TITLE
Feature/private dek not required for file storage packages

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -10,7 +10,7 @@
   "bugs": "https://github.com/Meeco/cli/issues",
   "dependencies": {
     "@meeco/cryppo": "^0.9.0",
-    "@meeco/file-storage-node": "2.0.0",
+    "@meeco/file-storage-node": "2.0.1",
     "@meeco/keystore-api-sdk": "^0.14.0",
     "@meeco/sdk": "^1.0.0",
     "@meeco/vault-api-sdk": "^0.19.0",

--- a/packages/file-storage-browser/package.json
+++ b/packages/file-storage-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meeco/file-storage-browser",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Browser module for uploading and downloading encrypted files",
   "source": "src/index.ts",
   "types": "./lib/index.d.ts",
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@meeco/vault-api-sdk": "^0.19.0",
-    "@meeco/file-storage-common": "^2.0.0",
+    "@meeco/file-storage-common": "^2.0.1",
     "@meeco/cryppo": "^0.9.0",
     "axios": "^0.20.0"
   },

--- a/packages/file-storage-common/package.json
+++ b/packages/file-storage-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meeco/file-storage-common",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Core module for uploading and downloading encrypted files",
   "source": "src/index.ts",
   "types": "./lib/index.d.ts",

--- a/packages/file-storage-common/src/index.ts
+++ b/packages/file-storage-common/src/index.ts
@@ -111,6 +111,10 @@ export async function downloadAttachment(
   vaultUrl: string,
   fetchApi?: any
 ) {
+  if (!auth.data_encryption_key) {
+    // this file must have been uploaded with the old form of file upload which needs the user's private DEK
+    throw new Error('auth.data_encryption_key is needed to download this particular file');
+  }
   return downloadAndDecryptFile(
     () => new AttachmentApi(buildApiConfig(auth, vaultUrl, fetchApi)).attachmentsIdDownloadGet(id),
     auth.data_encryption_key

--- a/packages/file-storage-common/src/index.ts
+++ b/packages/file-storage-common/src/index.ts
@@ -14,7 +14,7 @@ export { AzureBlockUpload } from './azure-block-upload';
 export { BlobStorage } from './services/Azure';
 
 export interface IFileStorageAuthConfiguration {
-  data_encryption_key: string;
+  data_encryption_key?: string;
   vault_access_token: string;
   delegation_id?: string;
   subscription_key?: string;

--- a/packages/file-storage-node/package.json
+++ b/packages/file-storage-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meeco/file-storage-node",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "",
   "source": "src/index.ts",
   "main": "lib/index.js",
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "@meeco/cryppo": "^0.9.0",
-    "@meeco/file-storage-common": "^2.0.0",
+    "@meeco/file-storage-common": "^2.0.1",
     "@meeco/vault-api-sdk": "^0.19.0",
     "bili": "^4.10.0",
     "file-saver": "^2.0.2",


### PR DESCRIPTION
Change private dek to "not required" for file downloads as it's not needed in almost all situations.