### PR TITLE
Removed extra param for EncryptionKey.toJson()

### DIFF
--- a/packages/sdk/src/models/encryption-key.ts
+++ b/packages/sdk/src/models/encryption-key.ts
@@ -38,7 +38,7 @@ export class EncryptionKey {
   /**
    * Implicitly called by `JSON.stringify()` to ensure that the value is safely printable
    */
-  toJSON(key) {
+  toJSON() {
     return cryppo.encodeSafe64(this._value);
   }
 }


### PR DESCRIPTION
toJson() is not a static method, no need to have the extraneous 'key' param