### PR TITLE
Set 'x-ms-blob-cache-control': 'public, max-age=604800' for block upl…

### DIFF
--- a/packages/file-storage-common/src/services/Azure/BlobStorage.ts
+++ b/packages/file-storage-common/src/services/Azure/BlobStorage.ts
@@ -46,6 +46,7 @@ const putBlockList = async (sasUrl, blockIDList, fileType) => {
       ...buildAzureHeaders(),
       'x-ms-blob-content-type': fileType,
       'Content-Type': 'text/xml',
+      'x-ms-blob-cache-control': 'public, max-age=86400',
     },
     data,
   });


### PR DESCRIPTION
Add 'x-ms-blob-cache-control': 'public, max-age=604800' for block uploads.
Later when when downloading response has `Cache-Control: public, max-age=604800` header set.