### PR TITLE
Hotfix/sdk alias itemresp

### DIFF
--- a/packages/sdk/src/models/decrypted-item.ts
+++ b/packages/sdk/src/models/decrypted-item.ts
@@ -88,9 +88,9 @@ export class DecryptedItem extends ItemMap<SDKDecryptedSlot> {
     this.classification_nodes =
       this.allClassificationNodes.filter(x => item.classification_node_ids.some(y => y === x.id)) ||
       [];
-    this.attachments = extra.attachments || [];
 
     // TODO do these need to be filtered by id?
+    this.attachments = extra.attachments || [];
     this.thumbnails = extra.thumbnails || [];
     this.associations = extra.associations || [];
     this.associations_to = extra.associations_to || [];

--- a/packages/sdk/src/models/decrypted-item.ts
+++ b/packages/sdk/src/models/decrypted-item.ts
@@ -17,12 +17,13 @@ import { NewSlot, SDKDecryptedSlot } from './slot-types';
 
 /**
  * Wraps Items returned from the API that have been decrypted, usually by {@link ItemService}.
- * If `associations`, `classification_nodes` and `attachements`are provided at construction, they are stored.
- *
- * Note that {@link classification_nodes} is not the same as `ItemResponse.classification_nodes`, it is just the
- * classifications that apply to the Item!
+ * If `associations`, `classification_nodes`, `thumbnails` and `attachments`are provided at construction, they are stored.
  *
  * `DecryptedItem` is immutable, you should use {@link toItemUpdate} to stage modifications.
+ *
+ * Note that when using [[fromAPI]] to construct a [[DecryptedItem]] {@link classification_nodes}, [[associations_to]] and
+ * [[associations]] are filtered to just those that concern the Item.
+ * [[thumbnails]] and [[attachments]] are NOT filtered; they may contain extra attachments not used by the Item.
  */
 export class DecryptedItem extends ItemMap<SDKDecryptedSlot> {
   public static readonly cryppo = (<any>global).cryppo || cryppo;
@@ -89,11 +90,12 @@ export class DecryptedItem extends ItemMap<SDKDecryptedSlot> {
       this.allClassificationNodes.filter(x => item.classification_node_ids.some(y => y === x.id)) ||
       [];
 
-    // TODO do these need to be filtered by id?
+    // TODO do these need to be filtered
     this.attachments = extra.attachments || [];
     this.thumbnails = extra.thumbnails || [];
-    this.associations = extra.associations || [];
-    this.associations_to = extra.associations_to || [];
+
+    this.associations = extra.associations?.filter(x => x.associated_from_id === this.id) || [];
+    this.associations_to = extra.associations_to?.filter(x => x.associated_to_id === this.id) || [];
   }
 
   /** True if you are the original creator of this Item */

--- a/packages/sdk/test/services/item-service.test.ts
+++ b/packages/sdk/test/services/item-service.test.ts
@@ -305,7 +305,7 @@ describe('ItemService', () => {
   });
 
   describe('#listDecrypted', () => {
-    const response = {
+    const mockResponse = {
       items: [
         {
           id: 'a',
@@ -354,14 +354,16 @@ describe('ItemService', () => {
           .matchHeader('Authorization', '2FPN4n5T68xy78i6HHuQ')
           .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
           .reply(200, {
-            ...response,
+            ...mockResponse,
             items: [],
             slots: [],
           })
       )
       .add('response', async () => await new ItemService(environment).listDecrypted(testUserAuth))
       .it('works for no items', ({ response }) => {
+        // tslint:disable-next-line:no-unused-expression
         expect(response.items).to.be.empty;
+        // tslint:disable-next-line:no-unused-expression
         expect(response.meta).to.be.empty;
       });
 
@@ -372,7 +374,7 @@ describe('ItemService', () => {
           .get('/items')
           .matchHeader('Authorization', '2FPN4n5T68xy78i6HHuQ')
           .matchHeader('Meeco-Subscription-Key', 'environment_subscription_key')
-          .reply(200, response)
+          .reply(200, mockResponse)
       )
       .add('response', async () => await new ItemService(environment).listDecrypted(testUserAuth))
       .it('list items and decrypts their slots', ({ response }) => {


### PR DESCRIPTION
Backwards compatible fixes, will be released as SDK 2.2.0
- Add type alias `SDKItemsResponse = ItemsResponse1` should fix namespace issues
- Add convenience function `listDecrypted()` that fetches and decrypts Items