### PR TITLE
fix attachment download using CLI command

### DIFF
--- a/packages/file-storage-common/src/auth.ts
+++ b/packages/file-storage-common/src/auth.ts
@@ -67,6 +67,10 @@ export function getBlobHeaders(auth: IFileStorageAuthConfiguration): { [header: 
     headers['Meeco-Subscription-Key'] = auth.subscription_key;
   }
 
+  if (auth.vault_access_token) {
+    headers['Authorization'] = auth.vault_access_token;
+  }
+
   if (auth.oidc_token) {
     headers['authorizationoidc2'] = auth.oidc_token;
   }

--- a/packages/file-storage-node/src/lib.ts
+++ b/packages/file-storage-node/src/lib.ts
@@ -1,4 +1,4 @@
-import { bytesToBinaryString, EncryptionKey } from '@meeco/cryppo';
+import { bytesToBinaryString, bytesToUtf8, EncryptionKey } from '@meeco/cryppo';
 import * as Common from '@meeco/file-storage-common';
 import {
   AzureBlockDownload,
@@ -163,7 +163,7 @@ export async function largeFileDownloadNode(
   const encryptionArtifacts: any = await AzureBlockDownload.download(
     artifactsUrl,
     authConfig
-  ).then((result: any) => JSON.parse(result.toString('utf-8')));
+  ).then((result: any) => JSON.parse(bytesToUtf8(result)));
 
   const blocks: Buffer[] = [];
 


### PR DESCRIPTION
bug fix for command  `meeco items:get-attachment my-attachment-item-id my-attachment-slot-id -o ./`