### PR TITLE
Run pre-test version checks and automatically tag alpha/beta versions

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -17,7 +17,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install
-      - run: npx lerna run test
+      - run: npm test
         env:
           CI: true
       # We want to ensure there are no issues the demo builds as well

--- a/.github/workflows/cli-create-release.yaml
+++ b/.github/workflows/cli-create-release.yaml
@@ -19,7 +19,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install
-      - run: npx lerna run test
+      - run: npm test
         env:
           CI: true
       - run: npx lerna run build

--- a/.github/workflows/file-storage-beta-release.yaml
+++ b/.github/workflows/file-storage-beta-release.yaml
@@ -20,7 +20,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install
-      - run: npx lerna run test
+      - run: npm test
         env:
           CI: true
       # It is currently a dependency

--- a/.github/workflows/file-storage-beta-release.yaml
+++ b/.github/workflows/file-storage-beta-release.yaml
@@ -25,6 +25,8 @@ jobs:
           CI: true
       # It is currently a dependency
       - run: npx lerna run build --scope '@meeco/sdk'
+      # Tag all versions with `-beta` and update all inter-dependant packages to use "beta" as the version
+      - run: npm run beta
       - run: npx lerna run build --scope '@meeco/{file-storage-common,file-storage-browser,file-storage-node}'
       - name: Publish NPM
         run: |

--- a/.github/workflows/file-storage-create-release.yaml
+++ b/.github/workflows/file-storage-create-release.yaml
@@ -21,7 +21,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install
-      - run: npx lerna run test
+      - run: npm test
         env:
           CI: true
       # It is currently a dependency

--- a/.github/workflows/sdk-alpha-release.yaml
+++ b/.github/workflows/sdk-alpha-release.yaml
@@ -23,6 +23,8 @@ jobs:
       - run: npx lerna run test --scope @meeco/sdk
         env:
           CI: true
+      # Tag all versions with `-alpha` and update all inter-dependant packages to use "alpha" as the version
+      - run: npm run alpha
       - run: npx lerna run build --scope @meeco/sdk
       - name: Publish NPM
         run: |

--- a/.github/workflows/sdk-beta-release.yaml
+++ b/.github/workflows/sdk-beta-release.yaml
@@ -23,6 +23,8 @@ jobs:
       - run: npx lerna run test --scope '@meeco/{sdk,sdk-demo}'
         env:
           CI: true
+      # Tag all versions with `-beta` and update all inter-dependant packages to use "beta" as the version
+      - run: npm run beta
       - run: npx lerna run build --scope @meeco/sdk
       - name: Publish NPM
         run: |

--- a/.github/workflows/sdk-demo-beta-release.yaml
+++ b/.github/workflows/sdk-demo-beta-release.yaml
@@ -21,6 +21,8 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install
+      # Tag all versions with `-beta` and update all inter-dependant packages to use "beta" as the version
+      - run: npm run beta
       - name: Build SDK Demo
         run:  npx lerna run build --scope @meeco/sdk-demo
       - name: Deploy SDK Demo GH page

--- a/.github/workflows/style-kit-create-release.yaml
+++ b/.github/workflows/style-kit-create-release.yaml
@@ -21,7 +21,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install
-      - run: npx lerna run test
+      - run: npm test
         env:
           CI: true
       - run: npx lerna run build --scope @meeco/style-kit

--- a/package.json
+++ b/package.json
@@ -7,11 +7,18 @@
     "build": "lerna run build",
     "docs": "lerna run docs",
     "postinstall": "npm run bootstrap",
-    "test": "lerna run test"
+    "alpha": "ts-node scripts/tag-packages.ts alpha",
+    "beta": "ts-node scripts/tag-packages.ts beta",
+    "test": "lerna run test",
+    "pretest": "ts-node scripts/check-packages.ts"
   },
   "devDependencies": {
     "chalk": "^4.0.0",
     "cypress": "^4.12.0",
-    "lerna": "^3.22.0"
+    "lerna": "^3.22.0",
+    "semver": "^7.3.4",
+    "ts-node": "^9.1.1",
+    "tsconfig-paths": "^3.9.0",
+    "typescript": "^4.2.2"
   }
 }

--- a/packages/file-storage-browser/package.json
+++ b/packages/file-storage-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meeco/file-storage-browser",
-  "version": "3.2.0-beta",
+  "version": "3.2.1",
   "description": "Browser module for uploading and downloading encrypted files",
   "source": "src/index.ts",
   "types": "./lib/index.d.ts",

--- a/packages/file-storage-node/package.json
+++ b/packages/file-storage-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meeco/file-storage-node",
-  "version": "3.2.0-beta",
+  "version": "3.2.1",
   "description": "",
   "source": "src/index.ts",
   "main": "lib/index.js",

--- a/packages/sdk/src/util/api-factory.ts
+++ b/packages/sdk/src/util/api-factory.ts
@@ -36,7 +36,10 @@ interface IHeaders {
 /**
  * Pluck environment and user auth values to create `apiKey` [Keystore.Configuration] parameter
  */
-const keystoreAPIKeys = (environment: Environment, userAuth: IKeystoreToken) => (name: string) =>
+const keystoreAPIKeys = (
+  environment: Environment,
+  userAuth: IKeystoreToken
+): ((name: string) => string) => (name: string) =>
   ({
     'Meeco-Subscription-Key': environment.keystore.subscription_key,
     // Must be uppercase
@@ -44,7 +47,7 @@ const keystoreAPIKeys = (environment: Environment, userAuth: IKeystoreToken) => 
     'Authorization': userAuth.keystore_access_token,
     'Meeco-Delegation-Id': userAuth.delegation_id || '',
     authorizationoidc2: userAuth.oidc_token || '',
-  }[name]);
+  }[name] as string);
 
 /**
  * Pluck environment and user auth values to create `apiKey` [Vault.Configuration] parameter
@@ -57,7 +60,7 @@ const vaultAPIKeys = (environment: Environment, userAuth: IVaultToken) => (name:
     'Authorization': userAuth.vault_access_token,
     'Meeco-Delegation-Id': userAuth.delegation_id || '',
     authorizationoidc2: userAuth.oidc_token || '',
-  }[name]);
+  }[name] as string);
 
 function fetchInterceptor(url, options) {
   debugCurl(blue(`Sending Request:`));
@@ -133,7 +136,7 @@ const keystoreAPI = (
             Keystore,
             api,
             apiMethodName,
-            keystoreAPIKeys(environment, userAuth),
+            keystoreAPIKeys(environment, userAuth) as (name: string) => string,
             environment.keystore.url,
             {
               ...additionalHeaders,
@@ -165,7 +168,7 @@ const vaultAPI = (
             Vault,
             api,
             apiMethodName,
-            vaultAPIKeys(environment, userAuth),
+            vaultAPIKeys(environment, userAuth) as (name: string) => string,
             environment.vault.url,
             {
               ...additionalHeaders,

--- a/scripts/check-packages.ts
+++ b/scripts/check-packages.ts
@@ -58,7 +58,7 @@ function checkPackageVersions(packageList: string[], packageDetails: PackageMap)
     const { version: coerced } = semver.coerce(version);
     if (version !== coerced) {
       console.error(
-        `Package ${packageDetails[name].name} version is listed as "${version}" which coerced to ${coerced} which is invalid`
+        `Package ${packageDetails[name].name} version is listed as "${version}" (coerced to "${coerced}") which is invalid`
       );
       console.error(
         `Packages should use valid semver versions without any pre-release tags (try just using "${coerced}")`
@@ -81,6 +81,7 @@ function checkPackageNames(packageList: string[], packageDetails: PackageMap) {
       console.error(
         `Package folder ${name} package.json expected name "@meeco/${name}" but got "${packageFileName}"`
       );
+      console.error(`Package names must be in the format @meeco/{folder name in packages/}`);
       process.exit(1);
     }
   });
@@ -113,7 +114,7 @@ function checkApiSdkDependencies(packageList: string[], packageDetails: PackageM
     const max = semver.maxSatisfying(requiredVersions, '>=0.0.0');
     if (!semver.satisfies(min, max)) {
       console.error(
-        `One or more packages requires "${api}" version "^${min}" which would conflict with "^${max}"`
+        `One or more packages requires "${api}" version "^${min}" which would conflict with higher version found of "^${max}"`
       );
       console.error(`Dependencies on API SDK's should be kept in sync to avoid duplicate installs`);
       process.exit(1);

--- a/scripts/check-packages.ts
+++ b/scripts/check-packages.ts
@@ -1,0 +1,122 @@
+import { getProjectList, PackageMap } from './get-project-list';
+
+const semver = require('semver');
+
+/**
+ * Run some sanity checks on all package files.
+ */
+(function main() {
+  const { packageList, packageDetails } = getProjectList();
+  checkPackageNames(packageList, packageDetails);
+  checkPackageVersions(packageList, packageDetails);
+  checkDependencies(packageList, packageDetails);
+  checkApiSdkDependencies(packageList, packageDetails);
+})();
+
+/**
+ * Ensure that for every package in `packages/*` that any other packages
+ * that depend on it have an applicable version in the repo.
+ */
+function checkDependencies(packageList: string[], packageDetails: PackageMap) {
+  console.log(`Check package dependencies`);
+  packageList.forEach((name) => {
+    const packageName = `@meeco/${name}`;
+    const version = packageDetails[name].package.version;
+    packageList.forEach((testPackage) => {
+      const pkg = packageDetails[testPackage].package;
+      const requiredVersion =
+        (pkg.dependencies || {})[packageName] || (pkg.devDependencies || {})[packageName];
+
+      if (requiredVersion === 'beta') {
+        console.error(`${packageName} requires ${testPackage}@beta - this should not be committed`);
+        process.exit(1);
+      }
+
+      if (requiredVersion) {
+        if (!semver.satisfies(version, requiredVersion)) {
+          console.error(
+            `Package "@meeco/${testPackage}" expected version ${requiredVersion} of ${packageName} but the repo has ${version}`
+          );
+          console.error(
+            `All package dependencies *must* be able to be resolved from within the repo`
+          );
+          process.exit(1);
+        }
+      }
+    });
+  });
+  console.log(`All package dependencies can be satisfied`);
+}
+
+/**
+ * Ensure that all versions conform to semver
+ */
+function checkPackageVersions(packageList: string[], packageDetails: PackageMap) {
+  console.log(`Check package versions`);
+  packageList.forEach((name) => {
+    const version = packageDetails[name].package.version;
+    const { version: coerced } = semver.coerce(version);
+    if (version !== coerced) {
+      console.error(
+        `Package ${packageDetails[name].name} version is listed as "${version}" which coerced to ${coerced} which is invalid`
+      );
+      console.error(
+        `Packages should use valid semver versions without any pre-release tags (try just using "${coerced}")`
+      );
+      process.exit(1);
+    }
+  });
+  console.log(`All packages versioned ok`);
+}
+
+/**
+ * Ensure that all package.json files in package/[package-name] are named
+ * `@meeco/[package-name]`
+ */
+function checkPackageNames(packageList: string[], packageDetails: PackageMap) {
+  console.log(`Check package names`);
+  packageList.forEach((name) => {
+    const packageFileName = packageDetails[name].package.name;
+    if (packageFileName !== `@meeco/${name}`) {
+      console.error(
+        `Package folder ${name} package.json expected name "@meeco/${name}" but got "${packageFileName}"`
+      );
+      process.exit(1);
+    }
+  });
+  console.log(`All packages named ok`);
+}
+
+/**
+ * Ensure that all dependents on `@meeco/vault-api-sdk` or `@meeco/keystore-api-sdk` are compatible
+ */
+function checkApiSdkDependencies(packageList: string[], packageDetails: PackageMap) {
+  const apiPackages = [`@meeco/vault-api-sdk`, `@meeco/keystore-api-sdk`];
+
+  apiPackages.forEach((api) => {
+    const requiredVersions: string[] = [];
+    packageList.forEach((pkg) => {
+      const requiredVersion = (packageDetails[pkg].package.dependencies || {})[api];
+      if (!requiredVersion) {
+        return;
+      }
+      if (!requiredVersion.startsWith('^')) {
+        console.error(`Package ${pkg} depends on ${api}@${requiredVersion} which is too specific`);
+        console.error(
+          `To avoid duplicate installs - packages should depend on ^ versions of API SDK's`
+        );
+        process.exit(1);
+      }
+      requiredVersions.push(requiredVersion.replace('^', ''));
+    });
+    const min = semver.minSatisfying(requiredVersions, '>=0.0.0');
+    const max = semver.maxSatisfying(requiredVersions, '>=0.0.0');
+    if (!semver.satisfies(min, max)) {
+      console.error(
+        `One or more packages requires "${api}" version "^${min}" which would conflict with "^${max}"`
+      );
+      console.error(`Dependencies on API SDK's should be kept in sync to avoid duplicate installs`);
+      process.exit(1);
+    }
+  });
+}

--- a/scripts/get-project-list.ts
+++ b/scripts/get-project-list.ts
@@ -1,0 +1,45 @@
+import { readdirSync, statSync, writeFileSync } from 'fs';
+import { join } from 'path';
+
+const packagesRoot = join(__dirname, '../', 'packages');
+
+export function getProjectList(): { packageList: string[]; packageDetails: PackageMap } {
+  const packageList = readdirSync(packagesRoot).filter((dir) =>
+    statSync(join(packagesRoot, dir)).isDirectory()
+  );
+
+  const packageDetails = packageList.reduce(
+    (prev, name) => ({
+      ...prev,
+      [name]: {
+        name,
+        package: require(join(packagesRoot, name, 'package.json')),
+      },
+    }),
+    {}
+  );
+
+  return {
+    packageList,
+    packageDetails,
+  };
+}
+
+/**
+ * Write modified packages back down to package.json files
+ */
+export function writePackages(packageList: string[], packageDetails: PackageMap) {
+  packageList.forEach((name) => {
+    writeFileSync(
+      join(packagesRoot, name, 'package.json'),
+      JSON.stringify(packageDetails[name].package, null, 2) + '\n'
+    );
+  });
+}
+
+export interface PackageMap {
+  [name: string]: {
+    name: string;
+    package: any;
+  };
+}

--- a/scripts/tag-packages.ts
+++ b/scripts/tag-packages.ts
@@ -1,0 +1,38 @@
+import { getProjectList, PackageMap, writePackages } from './get-project-list';
+const semver = require('semver');
+
+// note arg[0] = 'node' and arg[1] is the script name
+const tag = process.argv[2];
+if (tag !== 'alpha' && tag !== 'beta') {
+  console.error('Expected tag of "alpha" or "beta"');
+  process.exit(1);
+}
+
+/**
+ * For every package in the repo:
+ * - Tag the version with "-beta" pre-release tag
+ * - Update inter-dependant packages to list "beta" as the version
+ */
+(function main() {
+  const { packageList, packageDetails } = getProjectList();
+
+  updateDependentPackages(packageList, packageDetails);
+  writePackages(packageList, packageDetails);
+})();
+
+function updateDependentPackages(packageList: string[], packageDetails: PackageMap) {
+  packageList.forEach((name) => {
+    const packageName = packageDetails[name].package.name;
+    packageDetails[name].package.version =
+      semver.coerce(packageDetails[name].package.version) + `-${tag}`;
+
+    // Update all dependant packages
+    packageList.forEach((subPackage) => {
+      const pkg = packageDetails[subPackage].package;
+      if (pkg.dependencies && pkg.dependencies[packageName]) {
+        // Specify any "beta" which will just always get the latest published one
+        pkg.dependencies[packageName] = tag;
+      }
+    });
+  });
+}


### PR DESCRIPTION
This PR is an RFC to help address some ongoing mistakes commonly made in the repo. I'll leave this open for discussion for a bit as it might create some frustration in updating packages but overall I think it will encourage better practices.

This deprecates committing "-beta" versions to the repo.

The general idea is that the new "pretest" script (which is run automatically by npm when you run `npm test`) will check for following mistakes:

1. That your package name matches the name in the `packages` folder:  
![image](https://user-images.githubusercontent.com/9100419/109756769-705ba880-7c38-11eb-8cdb-d841cc4e25d8.png)

2. That you use valid semver versions (no `-beta` tags etc.):  
![image](https://user-images.githubusercontent.com/9100419/109756857-9c772980-7c38-11eb-8618-7b9f50211c4b.png)

3. That all inter-dependant packages can be satisfied from inside the repo. That is, if you are bumping the version of a package you have updated all other packages that depend on it to work with your changes:  
![image](https://user-images.githubusercontent.com/9100419/109756938-c3356000-7c38-11eb-853e-3f4891768810.png)

4. That all packages depend on semver compatible versions of "vault-api-sdk" and "keystore-api-sdk":  
![image](https://user-images.githubusercontent.com/9100419/109757057-f4159500-7c38-11eb-85c3-880dec687176.png)

As for publishing "beta" versions - there is another new script "tag-packages" which accepts an extra argument of "beta" or "alpha". This script will do the following:

- For *all* packages: add the `-beta` (or `-alpha`) pre-release tag to the current version
- Update all interdependent packages to just list `"beta"` (or `"alpha"`) as the required version (which npm knows how to resolve)

This script is run automatically in all the beta/alpha release workflows. The idea being that the packages are tagged before publish (so we never commit "beta" versions to the repo) and that we don't have to juggle "x.y.z-beta" versions of packages before publishing.

So essentially when making a change you just bump the semver version of the package you touch as applicable and the pretest script will yell at you with what to do from that point on.