### PR TITLE
Update vault sdk to 22.0.4 for file storage and sdk packages

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,7 +13,7 @@
     "@meeco/file-storage-node": "^3.1.1",
     "@meeco/keystore-api-sdk": "^5.3.0",
     "@meeco/sdk": "^2.1.0",
-    "@meeco/vault-api-sdk": "^22.0.2",
+    "@meeco/vault-api-sdk": "^22.0.4",
     "@oclif/command": "^1.5.19",
     "@oclif/config": "^1.13.3",
     "@oclif/plugin-help": "^2.2.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,7 +13,7 @@
     "@meeco/file-storage-node": "^3.1.1",
     "@meeco/keystore-api-sdk": "^5.3.0",
     "@meeco/sdk": "^2.1.0",
-    "@meeco/vault-api-sdk": "^22.0.0",
+    "@meeco/vault-api-sdk": "^22.0.2",
     "@oclif/command": "^1.5.19",
     "@oclif/config": "^1.13.3",
     "@oclif/plugin-help": "^2.2.1",

--- a/packages/file-storage-browser/package.json
+++ b/packages/file-storage-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meeco/file-storage-browser",
-  "version": "3.2.0-beta.1",
+  "version": "3.2.1",
   "description": "Browser module for uploading and downloading encrypted files",
   "source": "src/index.ts",
   "types": "./lib/index.d.ts",
@@ -22,7 +22,7 @@
   "dependencies": {
     "@meeco/cryppo": "^2.0.0",
     "@meeco/file-storage-common": "^4.0.0",
-    "@meeco/vault-api-sdk": "^22.0.0",
+    "@meeco/vault-api-sdk": "^22.0.4",
     "axios": "^0.21.1"
   },
   "devDependencies": {

--- a/packages/file-storage-browser/src/lib.ts
+++ b/packages/file-storage-browser/src/lib.ts
@@ -1,5 +1,4 @@
 import { bytesBufferToBinaryString, EncryptionKey } from '@meeco/cryppo';
-import * as Common from '@meeco/file-storage-common';
 import {
   AzureBlockDownload,
   buildApiConfig,
@@ -183,9 +182,8 @@ export async function downloadAttachment({
     );
     buffer = downloaded.byteArray;
   } else {
-    // was not uploaded in chunks
-    const downloaded = await Common.downloadAttachment(attachmentId, dek, authConfig, vaultUrl);
-    buffer = downloaded || new Uint8Array();
+    // legacy file upload no longer supported
+    throw new Error('Unsupported attachment download');
   }
 
   return new File([buffer], fileName, {

--- a/packages/file-storage-common/package.json
+++ b/packages/file-storage-common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meeco/file-storage-common",
-  "version": "4.0.0-beta",
+  "version": "4.0.1",
   "description": "Core module for uploading and downloading encrypted files",
   "source": "src/index.ts",
   "types": "./lib/index.d.ts",

--- a/packages/file-storage-common/src/index.ts
+++ b/packages/file-storage-common/src/index.ts
@@ -1,13 +1,11 @@
 import {
   binaryStringToBytesBuffer,
-  bytesBufferToBinaryString,
   CipherStrategy,
   decryptWithKey,
   EncryptionKey,
   encryptWithKey,
 } from '@meeco/cryppo';
 import {
-  AttachmentApi,
   AttachmentDirectUploadUrl,
   DirectAttachment,
   DirectAttachmentsApi,
@@ -128,37 +126,6 @@ export async function getAttachmentInfo(
 ): Promise<DirectAttachment> {
   const api = new DirectAttachmentsApi(buildApiConfig(auth, vaultUrl, fetchApi));
   return api.directAttachmentsIdGet(id).then(response => response.attachment);
-}
-
-export async function downloadAttachment(
-  id: string,
-  dek: EncryptionKey,
-  auth: IFileStorageAuthConfiguration,
-  vaultUrl: string,
-  fetchApi?: any
-) {
-  return downloadAndDecryptFile(
-    () => new AttachmentApi(buildApiConfig(auth, vaultUrl, fetchApi)).attachmentsIdDownloadGet(id),
-    dek
-  );
-}
-
-export async function downloadAndDecryptFile<T extends Blob>(
-  download: () => Promise<T>,
-  dataEncryptionKey: EncryptionKey
-) {
-  const result = await download();
-  // Chrome `Blob` objects support the arrayBuffer() methods but Safari do not - only on `Response`
-  // https://stackoverflow.com/questions/15341912/how-to-go-from-blob-to-arraybuffer
-  const buffer = await ((<any>result).arrayBuffer
-    ? (<any>result).arrayBuffer()
-    : new Response(result).arrayBuffer());
-  const encryptedContents = await bytesBufferToBinaryString(buffer);
-  const decryptedContents = await decryptWithKey({
-    serialized: encryptedContents,
-    key: dataEncryptionKey,
-  });
-  return decryptedContents;
 }
 
 /* ---------- Thumbnails ---------- */

--- a/packages/file-storage-node/package.json
+++ b/packages/file-storage-node/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@meeco/cryppo": "^2.0.0",
     "@meeco/file-storage-common": "^4.0.0",
-    "@meeco/vault-api-sdk": "^22.0.0",
+    "@meeco/vault-api-sdk": "^22.0.4",
     "bili": "^4.10.0",
     "file-saver": "^2.0.2",
     "file-type": "^15.0.0",

--- a/packages/file-storage-node/package.json
+++ b/packages/file-storage-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meeco/file-storage-node",
-  "version": "3.2.0-beta.1",
+  "version": "3.2.1",
   "description": "",
   "source": "src/index.ts",
   "main": "lib/index.js",

--- a/packages/file-storage-node/src/lib.ts
+++ b/packages/file-storage-node/src/lib.ts
@@ -133,13 +133,7 @@ export async function downloadAttachment(
     );
     buffer = downloaded.byteArray;
   } else {
-    const downloaded = await Common.downloadAttachment(
-      attachmentId,
-      attachmentDek,
-      authConfig,
-      environment.vault.url
-    );
-    buffer = Buffer.from(downloaded || '');
+    throw new Error('Unsupported attachment download');
   }
   return { fileName, buffer };
 }

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@meeco/cryppo": "^2.0.0",
     "@meeco/keystore-api-sdk": "^5.3.0",
-    "@meeco/vault-api-sdk": "^22.0.0",
+    "@meeco/vault-api-sdk": "^22.0.2",
     "@types/node-forge": "~0.9.0",
     "@types/parameterize": "^1.0.1",
     "base58-string": "0.0.3",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@meeco/cryppo": "^2.0.0",
     "@meeco/keystore-api-sdk": "^5.3.0",
-    "@meeco/vault-api-sdk": "^22.0.2",
+    "@meeco/vault-api-sdk": "^22.0.4",
     "@types/node-forge": "~0.9.0",
     "@types/parameterize": "^1.0.1",
     "base58-string": "0.0.3",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@meeco/sdk",
   "description": "A wrapper library around Meeco's various API SDK's and encryption libraries",
-  "version": "2.2.1",
+  "version": "2.2.2",
   "author": "Meeco",
   "bugs": "https://github.com/Meeco/cli/issues",
   "source": "src/index.ts",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@meeco/sdk",
   "description": "A wrapper library around Meeco's various API SDK's and encryption libraries",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "author": "Meeco",
   "bugs": "https://github.com/Meeco/cli/issues",
   "source": "src/index.ts",

--- a/packages/sdk/src/services/item-service.ts
+++ b/packages/sdk/src/services/item-service.ts
@@ -1,4 +1,4 @@
-import { Item, ItemApi, ItemsResponse1, Share } from '@meeco/vault-api-sdk';
+import { Item, ItemApi, ItemsResponse, Share } from '@meeco/vault-api-sdk';
 import { DecryptedItem } from '../models/decrypted-item';
 import DecryptedKeypair from '../models/decrypted-keypair';
 import { ItemUpdate } from '../models/item-update';
@@ -27,11 +27,8 @@ export interface IItemListFilterOptions {
   own?: boolean;
 }
 
-/** Quick fix for overloaded swagger type. */
-export type SDKItemsResponse = ItemsResponse1;
-
 /** DecryptedItems together with response metadata if needed for paging etc. */
-export type DecryptedItems = Pick<SDKItemsResponse, 'meta' | 'next_page_after'> & {
+export type DecryptedItems = Pick<ItemsResponse, 'meta' | 'next_page_after'> & {
   items: DecryptedItem[];
 };
 
@@ -107,7 +104,7 @@ export class ItemService extends Service<ItemApi> {
     credentials: IVaultToken,
     listFilterOptions?: IItemListFilterOptions,
     options?: IPageOptions
-  ): Promise<SDKItemsResponse> {
+  ): Promise<ItemsResponse> {
     const { classificationNodeName, classificationNodeNames } = this.getClassifications(
       listFilterOptions
     );
@@ -153,7 +150,7 @@ export class ItemService extends Service<ItemApi> {
   public async listAll(
     credentials: IVaultToken,
     listFilterOptions?: IItemListFilterOptions
-  ): Promise<SDKItemsResponse> {
+  ): Promise<ItemsResponse> {
     const api = this.vaultAPIFactory(credentials).ItemApi;
 
     const { classificationNodeName, classificationNodeNames } = this.getClassifications(


### PR DESCRIPTION
Removes the ItemsResponse1 references which are no longer required as a result