### PR TITLE
make style kit importable with all assets by adding url-loader which …

### DIFF
--- a/packages/file-storage-browser/demo/index.ts
+++ b/packages/file-storage-browser/demo/index.ts
@@ -160,9 +160,7 @@ async function attachFile() {
         {
           label,
           slot_type_name: 'attachment',
-          attachment_attributes: {
-            id: attachment.id,
-          },
+          attachment_id: attachment.id,
           value: attachmentDek.serialize,
         },
       ],

--- a/packages/file-storage-browser/demo/styles.scss
+++ b/packages/file-storage-browser/demo/styles.scss
@@ -1,4 +1,4 @@
-@import '../../style-kit/main';
+@import '~@meeco/style-kit/build/main';
 
 html,
 body {

--- a/packages/file-storage-browser/package.json
+++ b/packages/file-storage-browser/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@meeco/cryppo": "2.0.2",
     "@meeco/file-storage-common": "^5.0.0",
+    "@meeco/style-kit": "^2.0.1",
     "@meeco/vault-api-sdk": "32.0.0-stage.20210527103605.f1f76f0",
     "axios": "^0.21.1"
   },

--- a/packages/sdk-demo/package.json
+++ b/packages/sdk-demo/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@meeco/sdk": "^3.0.0",
+    "@meeco/style-kit": "^2.0.1",
     "clean-webpack-plugin": "^3.0.0",
     "html-webpack-plugin": "^4.5.2",
     "mithril": "^2.0.4",

--- a/packages/sdk-demo/src/styles.scss
+++ b/packages/sdk-demo/src/styles.scss
@@ -1,5 +1,4 @@
-// @import '../../style-kit/main';
-// TODO: import thisthis is not how to import this
+@import '~@meeco/style-kit/build/main';
 
 html,
 body {

--- a/packages/style-kit/README.md
+++ b/packages/style-kit/README.md
@@ -4,9 +4,17 @@ Styled building blocks for Meeco web applications.
 
 <img width="100px" src="https://uploads-ssl.webflow.com/5cd5168c6c861f4fc7cfe969/5ddcaba04d724676d8758927_Meeco-Logo-2019-Circle-RGB.svg">
 
-### Installation
+## Installation
 
-As with all projects in this repo, be sure to run `npm install` in the project root first.
+### In your node application/module
+
+1. Run `npm install --save @meeco/stylekit`
+2. Import the css file into the top of your main `scss` file with
+   `@import '~@meeco/style-kit/build/main';`
+
+## Usage
+
+For detailed usage instructions and examples see the docs at [https://meeco.github.io/sdk-docs/style-kit/?path=/docs/](https://meeco.github.io/sdk-docs/style-kit/?path=/docs/).
 
 ### Assets
 
@@ -24,6 +32,8 @@ node_modules/
 ```
 
 ### Development
+
+Once you have checked out this repository change to the project repository and run `npm install`.
 
 If you run `npm start` in this directory, it will start the [storybook](https://storybook.js.org/) project which should open itself in your default browser;
 

--- a/packages/style-kit/package.json
+++ b/packages/style-kit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@meeco/style-kit",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Meeco branded components and style mixins",
   "style": "build/main.css",
   "main": "build/bundle.js",
@@ -44,6 +44,7 @@
     "sass-loader": "^10.2.0",
     "start-server-and-test": "^1.12.3",
     "style-loader": "^1.3.0",
+    "url-loader": "^4.1.1",
     "webpack": "^4.46.0",
     "webpack-cli": "^3.3.12",
     "webpack-dev-server": "^3.11.2"

--- a/packages/style-kit/webpack.config.js
+++ b/packages/style-kit/webpack.config.js
@@ -20,7 +20,7 @@ module.exports = {
       },
       {
         test: /\.(ttf|eot|svg|woff)$/,
-        loader: 'file-loader',
+        loader: 'url-loader',
       },
     ],
   },


### PR DESCRIPTION
…turns fonts and images into base64 and embeds them in the css file. Add documentation for usage and a pointer to the docs. Also change sdk-demo and file-storage-browser demo to use the style-kit as documented.