### PR TITLE
file-storage-browser AttachmentService fetchApi binding fix

### DIFF
--- a/packages/file-storage-browser/src/attachment-service.ts
+++ b/packages/file-storage-browser/src/attachment-service.ts
@@ -6,7 +6,7 @@ import * as FileUtils from './FileUtils.web';
 
 export class AttachmentService extends Common.AttachmentService {
   constructor(vaultUrl: string) {
-    super(vaultUrl, fetch);
+    super(vaultUrl, (url, args) => window.fetch(url, args));
   }
 
   /**


### PR DESCRIPTION
When used with Angular, upload attachment service throws error: `Failed to execute 'fetch' on 'Window': Illegal invocation`.

To keep service more consistent with ThumbnailsService fetch is being passed as `(url, args) => window.fetch(url, args)`

`window.fetch.bind(window)` works as well.