### PR TITLE
updated module to correct es file path

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -6,7 +6,7 @@
   "bugs": "https://github.com/Meeco/cli/issues",
   "source": "src/index.ts",
   "main": "dist/index.js",
-  "module": "dist/index.esm.js",
+  "module": "dist/index.es.js",
   "types": "dist/src/index.d.ts",
   "dependencies": {
     "@meeco/cryppo": "2.0.2",


### PR DESCRIPTION
updated incorrect module name `dist/index.esm.js` to `dist/index.es.js`. 
when trying to use @meeco/sdk as npm package and compile it to the browser bundle, it throws a following error 

`Could not load './dist/index.esm.js' from module '@meeco/sdk' found in package.json#module`

