### PR TITLE
Expose vault connection deletion api

### DIFF
--- a/packages/sdk/src/services/connection-service.ts
+++ b/packages/sdk/src/services/connection-service.ts
@@ -78,11 +78,7 @@ export class ConnectionService extends Service<ConnectionApi> {
    * Throws an error if connection does not exist.
    */
   public async deleteConnection(credentials: IVaultToken, id: string) {
-    try {
       await this.vaultAPIFactory(credentials).ConnectionApi.connectionsIdDelete(id);
-    } catch (error) {
-      throw new Error(`Connection ${id} not found.`);
-    }
   }
 
   /**

--- a/packages/sdk/src/services/connection-service.ts
+++ b/packages/sdk/src/services/connection-service.ts
@@ -74,6 +74,18 @@ export class ConnectionService extends Service<ConnectionApi> {
   }
 
   /**
+   * Used for deleting a connection between two vaults.
+   * Throws an error if connection does not exist.
+   */
+  public async deleteConnection(credentials: IVaultToken, id: string) {
+    try {
+      await this.vaultAPIFactory(credentials).ConnectionApi.connectionsIdDelete(id);
+    } catch (error) {
+      throw new Error(`Connection ${id} not found.`);
+    }
+  }
+
+  /**
    * @deprecated Use {@link list} instead.
    * @param user
    */


### PR DESCRIPTION
Quick addition of the connection deletion endpoint to the SDK. 

Wrapped the call in a try-catch block. Call returns a void promise. 

Does it need error handling like this or is it fine to let the exception be thrown further down the line?